### PR TITLE
[Feat] Google News Crawler ADLS 연동 및 ACI 배포 컨테이너화

### DIFF
--- a/apps/google-news-crawler/.dockerignore
+++ b/apps/google-news-crawler/.dockerignore
@@ -1,0 +1,9 @@
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/.env
+**/.env.*
+**/data/
+**/output/
+**/raw_json/
+**/.git

--- a/apps/google-news-crawler/Dockerfile
+++ b/apps/google-news-crawler/Dockerfile
@@ -1,0 +1,49 @@
+# Google News Crawler — Azure Container Instance 배포용
+#
+# Base: Playwright 공식 이미지 (Chromium 내장)
+# 빌드 (리포지토리 루트에서 실행):
+#   az acr build --registry sense3dtacr \
+#     --image google-news-crawler:latest \
+#     --file apps/google-news-crawler/Dockerfile .
+#
+# ACI one-shot 실행 예시:
+#   az container create \
+#     --resource-group 3dt-2nd-team1 \
+#     --name sense-news-crawler \
+#     --image sense3dtacr.azurecr.io/google-news-crawler:latest \
+#     --registry-login-server sense3dtacr.azurecr.io \
+#     --registry-username <acr-admin-user> \
+#     --registry-password <acr-admin-password> \
+#     --assign-identity \
+#     --environment-variables \
+#         KEY_VAULT_URL=https://kv-3dt-team1.vault.azure.net/ \
+#         KEYWORDS="SK Hynix,Samsung Electronics" \
+#         DATE_START=2025-04-01 \
+#     --restart-policy Never \
+#     --location koreacentral
+#
+# ※ 실행 후 ACI MI에 아래 권한 부여 필요:
+#   - Key Vault Secrets User  (kv-3dt-team1)
+#   - Storage Blob Data Contributor  (3dtteam1adls)
+#
+# 필수 환경변수 (ACI 실행 시 --environment-variables 또는 --secure-environment-variables로 주입):
+#   KEY_VAULT_URL   : https://<vault-name>.vault.azure.net/
+#   KEYWORDS        : 콤마 구분 키워드  (기본: "SK Hynix,Samsung Electronics")
+#   DATE_START      : YYYY-MM-DD          (기본: "2025-04-01")
+#   DATE_END        : YYYY-MM-DD          (기본: 오늘)
+
+FROM mcr.microsoft.com/playwright/python:v1.49.1-jammy
+
+WORKDIR /app
+
+# requirements 먼저 복사 → 코드 변경 시 레이어 캐시 재사용
+COPY apps/google-news-crawler/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 크롤러 소스 복사 (google_news_crawler/ 내 모든 파일)
+COPY src/ingestion/google_news_crawler/ /app/
+
+# vault_manager를 /app/ 에 flat 복사 → "from vault_manager import ..." 로 직접 import
+COPY src/utils/vault_manager.py /app/vault_manager.py
+
+CMD ["python", "main.py"]

--- a/apps/google-news-crawler/requirements.txt
+++ b/apps/google-news-crawler/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp>=3.9.0
+playwright>=1.49.0
+tf-playwright-stealth>=1.0.6
+scrapling>=0.2.9
+pandas>=2.2.0
+pyarrow>=14.0.0
+azure-identity>=1.19.0
+azure-keyvault-secrets>=4.9.0
+azure-storage-file-datalake>=12.19.0
+python-dotenv>=1.0.0

--- a/src/ingestion/google_news_crawler/.gitignore
+++ b/src/ingestion/google_news_crawler/.gitignore
@@ -1,5 +1,0 @@
-repos/
-data/
-__pycache__/
-*.pyc
-.venv/

--- a/src/ingestion/google_news_crawler/.gitignore
+++ b/src/ingestion/google_news_crawler/.gitignore
@@ -1,0 +1,5 @@
+repos/
+data/
+__pycache__/
+*.pyc
+.venv/

--- a/src/ingestion/google_news_crawler/check_output.py
+++ b/src/ingestion/google_news_crawler/check_output.py
@@ -1,0 +1,25 @@
+import json
+
+for kw in ["SK_Hynix", "Samsung_Electronics"]:
+    records = []
+    try:
+        with open(f"data/output/{kw}_news.json", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    records.append(json.loads(line))
+        with_body = [r for r in records if r.get("body")]
+        body_lens = [len(r["body"]) for r in with_body]
+        avg_len = sum(body_lens) // len(body_lens) if body_lens else 0
+        rate = 100 * len(with_body) // len(records) if records else 0
+        print(f"=== {kw} ===")
+        print(f"  전체: {len(records)}건")
+        print(f"  본문 있음: {len(with_body)}건 ({rate}%)")
+        print(f"  본문 없음: {len(records) - len(with_body)}건")
+        print(f"  평균 본문 길이: {avg_len}자")
+        if records:
+            print(f"  샘플 헤드라인: {records[0]['headline'][:70]}")
+            print(f"  샘플 본문: {(records[0].get('body') or '')[:120]}")
+        print()
+    except FileNotFoundError:
+        print(f"{kw}: 파일 없음\n")

--- a/src/ingestion/google_news_crawler/config.py
+++ b/src/ingestion/google_news_crawler/config.py
@@ -1,0 +1,51 @@
+"""
+Google News 해외 뉴스 크롤러 설정 모듈
+- 1차 메타데이터: Google News RSS 피드 (CAPTCHA 없음)
+- 2차 본문: Playwright + stealth (원문 링크 방문)
+
+환경변수:
+  KEYWORDS    : 콤마 구분 검색 키워드 (기본: "SK Hynix,Samsung Electronics")
+  DATE_START  : 수집 시작일 YYYY-MM-DD (기본: "2025-04-01")
+  DATE_END    : 수집 종료일 YYYY-MM-DD (기본: 실행 당일)
+"""
+
+import os
+from datetime import datetime
+
+# ── 검색 대상 (env 주입 가능 — 콤마 구분) ────────────────────
+KEYWORDS: list[str] = [
+    k.strip() for k in os.getenv("KEYWORDS", "SK Hynix,Samsung Electronics").split(",") if k.strip()
+]
+
+# ── 검색 기간 ─────────────────────────────────────────────────
+DATE_START: str = os.getenv("DATE_START", "2025-04-01")
+DATE_END: str = os.getenv("DATE_END", datetime.today().strftime("%Y-%m-%d"))
+
+# ── 딜레이 설정 (초) ──────────────────────────────────────────
+RSS_DELAY_MIN = 1.0  # RSS 요청 간 최소 대기
+RSS_DELAY_MAX = 3.0  # RSS 요청 간 최대 대기
+BODY_MIN_DELAY = 0.3  # 본문 수집 시 기사 간 최소 대기
+BODY_MAX_DELAY = 1.0  # 본문 수집 시 기사 간 최대 대기
+PAGE_LOAD_TIMEOUT = 30_000  # ms — Playwright 타임아웃
+
+# ── 재시도 설정 ───────────────────────────────────────────────
+MAX_RETRIES = 3
+RETRY_BACKOFF = 2.0  # 지수 백오프 배수
+
+# ── 브라우저 설정 (본문 수집용) ───────────────────────────────
+HEADLESS = True  # 컨테이너 환경에서는 항상 headless
+VIEWPORT = {"width": 1920, "height": 1080}
+LOCALE = "en-US"
+TIMEZONE = "America/New_York"
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/136.0.0.0 Safari/537.36"
+)
+
+# ── Google News RSS 설정 ─────────────────────────────────────
+#    news.google.com/rss/search — CAPTCHA 없이 최대 100건/요청
+GOOGLE_NEWS_RSS_BASE = "https://news.google.com/rss/search"
+RSS_LANG = "en-US"  # hl 파라미터
+RSS_COUNTRY = "US"  # gl 파라미터
+RSS_CEID = "US:en"  # ceid 파라미터

--- a/src/ingestion/google_news_crawler/crawling_google_news.py
+++ b/src/ingestion/google_news_crawler/crawling_google_news.py
@@ -1,0 +1,464 @@
+"""
+Google News 해외 뉴스 크롤러
+1차 메타데이터: Google News RSS 피드 (aiohttp — CAPTCHA 없음)
+2차 본문 수집: Playwright + tf-playwright-stealth (원문 링크 방문)
+
+수집 대상: Google News 영문판 — SK Hynix, Samsung Electronics
+영문 기사만 수집 (비영문 기사 자동 필터링)
+"""
+
+import asyncio
+import hashlib
+import logging
+import random
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from urllib.parse import quote_plus
+
+import aiohttp
+from config import (
+    BODY_MAX_DELAY,
+    BODY_MIN_DELAY,
+    DATE_END,
+    DATE_START,
+    GOOGLE_NEWS_RSS_BASE,
+    HEADLESS,
+    KEYWORDS,
+    LOCALE,
+    MAX_RETRIES,
+    PAGE_LOAD_TIMEOUT,
+    RETRY_BACKOFF,
+    RSS_CEID,
+    RSS_COUNTRY,
+    RSS_DELAY_MAX,
+    RSS_DELAY_MIN,
+    RSS_LANG,
+    TIMEZONE,
+    USER_AGENT,
+    VIEWPORT,
+)
+from playwright.async_api import (
+    BrowserContext,
+    Page,
+    async_playwright,
+)
+from playwright.async_api import (
+    TimeoutError as PwTimeout,
+)
+from playwright_stealth import StealthConfig, stealth_async
+from scrapling import Selector
+
+from utils import (
+    clean_text,
+    generate_monthly_ranges,
+    load_checkpoint,
+    save_checkpoint,
+    save_final,
+    setup_logging,
+)
+
+logger = logging.getLogger("google_news")
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  영문 판별
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+# ASCII + 기본 라틴 확장 비율로 판별 (숫자/공백/구두점 포함)
+_LATIN_RE = re.compile(r"[A-Za-z0-9\s\.,;:!?\-'\"()\[\]{}/@#$%^&*+=<>~`]")
+
+
+def is_english(text: str, threshold: float = 0.70) -> bool:
+    """텍스트의 70% 이상이 ASCII 문자이면 영문으로 판별한다."""
+    if not text:
+        return False
+    latin_count = sum(1 for ch in text if _LATIN_RE.match(ch))
+    return (latin_count / len(text)) >= threshold
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  유틸
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def make_news_id(url: str) -> str:
+    """URL에서 고유 ID를 생성한다."""
+    return hashlib.sha256(url.encode()).hexdigest()[:16]
+
+
+def build_rss_url(keyword: str, start_date: str, end_date: str) -> str:
+    """Google News RSS 검색 URL을 생성한다.
+
+    날짜 필터: after:YYYY-MM-DD before:YYYY-MM-DD
+    """
+    query = f"{keyword} after:{start_date} before:{end_date}"
+    return (
+        f"{GOOGLE_NEWS_RSS_BASE}"
+        f"?q={quote_plus(query)}"
+        f"&hl={RSS_LANG}&gl={RSS_COUNTRY}&ceid={RSS_CEID}"
+    )
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  1차: RSS 피드에서 메타데이터 수집
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+async def fetch_rss(
+    session: aiohttp.ClientSession,
+    keyword: str,
+    start_date: str,
+    end_date: str,
+) -> list[dict]:
+    """한 달치 Google News RSS 피드를 가져와 파싱한다."""
+    month_label = start_date[:7]
+    url = build_rss_url(keyword, start_date, end_date)
+    now = datetime.now(timezone.utc).isoformat()
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/rss+xml, application/xml, text/xml, */*",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    for attempt in range(MAX_RETRIES):
+        try:
+            async with session.get(
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        "RSS HTTP %d (시도 %d/%d): %s %s",
+                        resp.status,
+                        attempt + 1,
+                        MAX_RETRIES,
+                        keyword,
+                        month_label,
+                    )
+                    if attempt < MAX_RETRIES - 1:
+                        await asyncio.sleep(RETRY_BACKOFF**attempt)
+                    continue
+                text = await resp.text()
+        except Exception as e:
+            logger.warning(
+                "RSS 요청 실패 (시도 %d/%d): %s — %s", attempt + 1, MAX_RETRIES, keyword, e
+            )
+            if attempt < MAX_RETRIES - 1:
+                await asyncio.sleep(RETRY_BACKOFF**attempt)
+            continue
+
+        # XML 파싱
+        try:
+            root = ET.fromstring(text)
+        except ET.ParseError as e:
+            logger.error("RSS XML 파싱 오류: %s — %s", keyword, e)
+            return []
+
+        channel = root.find("channel")
+        if channel is None:
+            return []
+
+        items = channel.findall("item")
+        records: list[dict] = []
+        skipped_lang = 0
+
+        for item in items:
+            title = item.findtext("title", "").strip()
+            link = item.findtext("link", "").strip()
+            pub_date_raw = item.findtext("pubDate", "").strip()
+            description_raw = item.findtext("description", "").strip()
+
+            # <source> 태그에서 언론사명
+            source_el = item.find("source")
+            press = source_el.text.strip() if source_el is not None and source_el.text else ""
+
+            # 영문 기사만 수집
+            if not is_english(title):
+                skipped_lang += 1
+                continue
+
+            # 날짜 파싱 (RFC 2822 → YYYY-MM-DD)
+            pub_date = ""
+            if pub_date_raw:
+                try:
+                    dt = parsedate_to_datetime(pub_date_raw)
+                    pub_date = dt.strftime("%Y-%m-%d")
+                except Exception:
+                    pub_date = pub_date_raw[:10]
+
+            # description에서 HTML 태그 제거
+            description = clean_text(re.sub(r"<[^>]+>", "", description_raw))
+
+            news_id = make_news_id(link)
+
+            records.append(
+                {
+                    "source": keyword,
+                    "newsId": news_id,
+                    "url": link,
+                    "pubDate": pub_date,
+                    "adjustedDate": month_label,
+                    "headline": clean_text(title),
+                    "press": press,
+                    "description": description,
+                    "body": "",
+                    "fetchedAt": now,
+                }
+            )
+
+        if skipped_lang:
+            logger.info("[%s] %s — 비영문 기사 %d건 제외", keyword, month_label, skipped_lang)
+        logger.info("[%s] %s — RSS에서 %d건 수집", keyword, month_label, len(records))
+        return records
+
+    return []
+
+
+async def collect_month_rss(
+    session: aiohttp.ClientSession,
+    keyword: str,
+    start_date: str,
+    end_date: str,
+) -> list[dict]:
+    """한 달치 메타데이터를 RSS로 수집한다."""
+    records = await fetch_rss(session, keyword, start_date, end_date)
+    # RSS 내 URL 중복 제거
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for r in records:
+        if r["url"] not in seen:
+            seen.add(r["url"])
+            unique.append(r)
+    return unique
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  2차: 본문 수집 (Playwright + stealth)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+async def create_stealth_page(playwright) -> tuple[BrowserContext, Page]:
+    browser = await playwright.chromium.launch(
+        headless=HEADLESS,
+        args=[
+            "--disable-blink-features=AutomationControlled",
+            "--no-sandbox",
+        ],
+    )
+    context = await browser.new_context(
+        viewport=VIEWPORT,
+        locale=LOCALE,
+        timezone_id=TIMEZONE,
+        user_agent=USER_AGENT,
+    )
+    page = await context.new_page()
+
+    stealth_cfg = StealthConfig(
+        webdriver=True,
+        chrome_app=True,
+        chrome_csi=True,
+        chrome_load_times=True,
+        chrome_runtime=True,
+        navigator_languages=True,
+        navigator_permissions=True,
+        navigator_plugins=True,
+        navigator_user_agent=True,
+        navigator_vendor=True,
+        webgl_vendor=True,
+        navigator_hardware_concurrency=True,
+        media_codecs=True,
+    )
+    await stealth_async(page, config=stealth_cfg)
+
+    return context, page
+
+
+def _extract_body_from_html(html: str) -> str:
+    """원문 페이지 HTML에서 본문을 추출한다."""
+    doc = Selector(content=html)
+
+    # 전략 1: <article> 태그 내 텍스트
+    article = doc.css("article")
+    if article:
+        paragraphs = article[0].css("p")
+        if paragraphs:
+            texts = [clean_text(p.get_all_text(strip=True)) for p in paragraphs]
+            body = " ".join(t for t in texts if len(t) > 20)
+            if len(body) > 100:
+                return body
+
+    # 전략 2: 모든 <p> 중 긴 것들
+    all_p = doc.css("p")
+    if all_p:
+        texts = [clean_text(p.get_all_text(strip=True)) for p in all_p]
+        long_texts = [t for t in texts if len(t) > 40]
+        if long_texts:
+            return " ".join(long_texts)
+
+    # 전략 3: meta description 폴백
+    meta_desc = doc.css('meta[property="og:description"]')
+    if meta_desc:
+        content = meta_desc[0].attrib.get("content", "")
+        if content:
+            return clean_text(content)
+    meta_desc2 = doc.css('meta[name="description"]')
+    if meta_desc2:
+        content = meta_desc2[0].attrib.get("content", "")
+        if content:
+            return clean_text(content)
+
+    return ""
+
+
+async def collect_bodies(page: Page, records: list[dict]) -> list[dict]:
+    """각 기사의 원문 링크를 방문하여 본문을 수집한다."""
+    total = len(records)
+    logger.info("본문 수집 시작: %d건", total)
+    success = 0
+
+    for i, rec in enumerate(records):
+        url = rec.get("url", "")
+        if not url or rec.get("body"):
+            continue
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                # Google News 프록시 URL → 실제 기사로 JS 리디렉트 대기
+                is_google_url = "news.google.com" in url
+                resp = await page.goto(url, wait_until="commit", timeout=PAGE_LOAD_TIMEOUT)
+
+                if is_google_url:
+                    try:
+                        await page.wait_for_url(
+                            lambda u: "news.google.com" not in u,
+                            timeout=8000,
+                        )
+                    except PwTimeout:
+                        logger.debug("Google 리디렉트 타임아웃: %s", url[:80])
+                        break
+
+                await page.wait_for_load_state("domcontentloaded")
+
+                # 리디렉트된 실제 URL로 업데이트
+                final_url = page.url
+                if final_url and final_url != url and "news.google.com" not in final_url:
+                    rec["url"] = final_url
+
+                if resp and resp.status >= 400:
+                    logger.debug("HTTP %d — %s", resp.status, url[:80])
+                    break
+
+                await asyncio.sleep(random.uniform(0.2, 0.5))
+
+                html = await page.content()
+                body = _extract_body_from_html(html)
+                if body:
+                    rec["body"] = body
+                    success += 1
+                break
+
+            except PwTimeout:
+                logger.debug("본문 타임아웃: %s", url[:80])
+                break
+            except Exception as e:
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(RETRY_BACKOFF**attempt)
+                else:
+                    logger.debug("본문 수집 실패 (%s): %s", url[:60], e)
+
+        if (i + 1) % 20 == 0:
+            logger.info("본문 수집 진행: %d/%d건 (성공 %d건)", i + 1, total, success)
+
+        await asyncio.sleep(random.uniform(BODY_MIN_DELAY, BODY_MAX_DELAY))
+
+    logger.info("본문 수집 완료: %d/%d건 성공", success, total)
+    return records
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  메인 오케스트레이션
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+async def crawl_keyword(keyword: str, date_start: str, date_end: str) -> list[dict]:
+    """특정 키워드의 뉴스를 한 달씩 끊어서 전체 수집한다.
+
+    Phase 1: RSS로 메타데이터 수집 (전체 월)
+    Phase 2: Playwright로 본문 수집
+    """
+    monthly_ranges = generate_monthly_ranges(date_start, date_end)
+    all_records: list[dict] = []
+
+    # ── Phase 1: RSS 메타데이터 ──
+    logger.info("[%s] Phase 1 — RSS 메타데이터 수집 시작 (%d개월)", keyword, len(monthly_ranges))
+
+    async with aiohttp.ClientSession() as session:
+        for start_date, end_date in monthly_ranges:
+            month_label = start_date[:7]
+
+            # 체크포인트 확인
+            cached = load_checkpoint(keyword, start_date)
+            if cached:
+                all_records.extend(cached)
+                logger.info(
+                    "[%s] %s — 체크포인트에서 로드 (%d건)", keyword, month_label, len(cached)
+                )
+                continue
+
+            records = await collect_month_rss(session, keyword, start_date, end_date)
+            save_checkpoint(records, keyword, start_date)
+            all_records.extend(records)
+
+            await asyncio.sleep(random.uniform(RSS_DELAY_MIN, RSS_DELAY_MAX))
+
+    logger.info("[%s] Phase 1 완료 — 총 %d건 메타데이터 수집", keyword, len(all_records))
+
+    if not all_records:
+        return []
+
+    # ── Phase 2: Playwright 본문 수집 ──
+    logger.info("[%s] Phase 2 — 본문 수집 시작 (%d건)", keyword, len(all_records))
+
+    async with async_playwright() as pw:
+        context, page = await create_stealth_page(pw)
+        try:
+            all_records = await collect_bodies(page, all_records)
+        finally:
+            await context.close()
+
+    logger.info("[%s] Phase 2 완료", keyword)
+    return all_records
+
+
+async def main() -> None:
+    setup_logging()
+    logger.info("=" * 60)
+    logger.info("Google News 해외 뉴스 크롤러 시작")
+    logger.info("키워드: %s", KEYWORDS)
+    logger.info("기간: %s ~ %s", DATE_START, DATE_END)
+    logger.info("모드: RSS 메타데이터 + Playwright 본문")
+    logger.info("필터: 영문 기사만 수집")
+    logger.info("=" * 60)
+
+    for keyword in KEYWORDS:
+        logger.info("━" * 40)
+        logger.info("키워드 수집 시작: %s", keyword)
+        logger.info("━" * 40)
+
+        records = await crawl_keyword(keyword, DATE_START, DATE_END)
+
+        if records:
+            adls_path = save_final(records, keyword)
+            logger.info("최종 저장 완료: %s", adls_path)
+        else:
+            logger.warning("수집된 데이터 없음: %s", keyword)
+
+    logger.info("=" * 60)
+    logger.info("전체 크롤링 완료")
+    logger.info("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ingestion/google_news_crawler/main.py
+++ b/src/ingestion/google_news_crawler/main.py
@@ -1,0 +1,23 @@
+"""
+Google News 크롤러 컨테이너 진입점
+
+환경변수로 키워드·날짜를 주입받아 결과를 ADLS Gen2에 저장한다.
+
+필수 환경변수:
+  KEY_VAULT_URL  : Azure Key Vault URL (https://<name>.vault.azure.net/)
+
+선택 환경변수 (기본값 있음):
+  KEYWORDS   : 콤마 구분 키워드  (기본: "SK Hynix,Samsung Electronics")
+  DATE_START : 수집 시작일 YYYY-MM-DD  (기본: "2025-04-01")
+  DATE_END   : 수집 종료일 YYYY-MM-DD  (기본: 오늘)
+
+결과 ADLS 경로:
+  raw/news/google/keyword={safe_keyword}/year={YYYY}/month={MM}/articles.parquet
+"""
+
+import asyncio
+
+from crawling_google_news import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ingestion/google_news_crawler/retry_samsung_body.py
+++ b/src/ingestion/google_news_crawler/retry_samsung_body.py
@@ -1,0 +1,159 @@
+"""
+Samsung Electronics 본문 재수집 스크립트
+- 빈 본문 또는 Google News 보일러플레이트가 들어간 기사만 재시도
+- wait_for_url 타임아웃을 15000ms로 늘려서 JS 리다이렉트 실패 최소화
+"""
+
+import asyncio
+import json
+import logging
+import random
+from pathlib import Path
+
+from config import (
+    MAX_RETRIES,
+    PAGE_LOAD_TIMEOUT,
+    RETRY_BACKOFF,
+)
+from crawling_google_news import _extract_body_from_html, create_stealth_page
+from playwright.async_api import TimeoutError as PwTimeout
+from playwright.async_api import async_playwright
+
+from utils import save_final, setup_logging
+
+logger = logging.getLogger("retry_samsung")
+
+# Google News가 meta description으로 삽입하는 보일러플레이트 텍스트
+BOILERPLATE = (
+    "Comprehensive up-to-date news coverage, aggregated from sources all over the world"
+    " by Google News."
+)
+
+REDIRECT_TIMEOUT = 15_000  # ms — SK하이닉스 대비 2배 여유
+PAGE_SETTLE_DELAY = (0.5, 1.5)  # 리다이렉트 후 페이지 안정화 대기
+
+
+def is_boilerplate(body: str) -> bool:
+    return BOILERPLATE.lower() in body.lower()
+
+
+async def retry_bodies(page, records: list[dict], label: str) -> int:
+    """본문이 없거나 보일러플레이트인 기사만 재시도. 성공 건수 반환."""
+    to_retry = [
+        (i, r)
+        for i, r in enumerate(records)
+        if not r.get("body") or is_boilerplate(r.get("body", ""))
+    ]
+    total = len(to_retry)
+    logger.info("[%s] 재수집 대상: %d건 (전체 %d건)", label, total, len(records))
+
+    success = 0
+    for seq, (idx, rec) in enumerate(to_retry):
+        url = rec.get("url", "")
+        if not url:
+            continue
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                is_google_url = "news.google.com" in url
+
+                await page.goto(url, wait_until="commit", timeout=PAGE_LOAD_TIMEOUT)
+
+                if is_google_url:
+                    try:
+                        await page.wait_for_url(
+                            lambda u: "news.google.com" not in u,
+                            timeout=REDIRECT_TIMEOUT,
+                        )
+                    except PwTimeout:
+                        logger.debug("리다이렉트 타임아웃: %s", url[:80])
+                        break
+
+                await page.wait_for_load_state("domcontentloaded")
+
+                # 페이지 안정화 대기 (JS 렌더링 여유)
+                await asyncio.sleep(random.uniform(*PAGE_SETTLE_DELAY))
+
+                final_url = page.url
+                if final_url and final_url != url and "news.google.com" not in final_url:
+                    records[idx]["url"] = final_url
+
+                html = await page.content()
+                body = _extract_body_from_html(html)
+
+                if body and not is_boilerplate(body):
+                    records[idx]["body"] = body
+                    success += 1
+                    break
+                else:
+                    logger.debug("본문 미흡 (attempt %d): %s", attempt + 1, url[:60])
+
+            except PwTimeout:
+                logger.debug("페이지 타임아웃: %s", url[:80])
+                break
+            except Exception as e:
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(RETRY_BACKOFF**attempt)
+                else:
+                    logger.debug("수집 실패: %s — %s", url[:60], e)
+
+        # 딜레이 (일반 수집보다 조금 더 여유있게)
+        await asyncio.sleep(random.uniform(0.5, 1.2))
+
+        if (seq + 1) % 20 == 0:
+            logger.info("[%s] 진행: %d/%d건 완료 (성공 %d건)", label, seq + 1, total, success)
+
+    logger.info("[%s] 재수집 완료: %d/%d건 성공", label, success, total)
+    return success
+
+
+async def main():
+    setup_logging()
+    logger.info("=" * 60)
+    logger.info("Samsung Electronics 본문 재수집 시작")
+    logger.info("=" * 60)
+
+    output_path = Path("data/output/Samsung_Electronics_news.json")
+    if not output_path.exists():
+        logger.error("파일 없음: %s", output_path)
+        return
+
+    # JSON 로드
+    records = []
+    with open(output_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+    logger.info("로드 완료: %d건", len(records))
+
+    before_empty = sum(1 for r in records if not r.get("body"))
+    before_boiler = sum(1 for r in records if r.get("body") and is_boilerplate(r["body"]))
+    logger.info("재수집 대상 — 빈 본문: %d건, 보일러플레이트: %d건", before_empty, before_boiler)
+
+    async with async_playwright() as pw:
+        context, page = await create_stealth_page(pw)
+        try:
+            await retry_bodies(page, records, "Samsung_Electronics")
+        finally:
+            await context.close()
+
+    # 결과 저장
+    save_final(records, "Samsung_Electronics")
+
+    after_no_body = sum(
+        1 for r in records if not r.get("body") or is_boilerplate(r.get("body", ""))
+    )
+    after_ok = len(records) - after_no_body
+    logger.info(
+        "최종 본문 보유: %d/%d건 (%.0f%%)", after_ok, len(records), after_ok / len(records) * 100
+    )
+    logger.info("저장 완료: data/output/Samsung_Electronics_news.json")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ingestion/google_news_crawler/utils.py
+++ b/src/ingestion/google_news_crawler/utils.py
@@ -1,0 +1,163 @@
+"""
+Google News 해외 뉴스 크롤러 유틸리티
+"""
+
+import io
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+# vault_manager: 컨테이너(/app/flat)와 로컈(src/utils/) 모두 지원
+try:
+    from vault_manager import get_vault_manager
+except ImportError:
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "utils"))
+    from vault_manager import get_vault_manager
+
+logger = logging.getLogger("google_news")
+
+# ── ADLS 경로 상수 ───────────────────────────────────────────────────────
+_ADLS_CONTAINER = "raw"
+_CHECKPOINT_PREFIX = "news/google/checkpoints"
+_OUTPUT_PREFIX = "news/google"
+
+
+# ── 로깅 설정 ────────────────────────────────────────────────
+def setup_logging(level: int = logging.INFO) -> None:
+    fmt = "[%(asctime)s] %(levelname)-7s %(message)s"
+    logging.basicConfig(level=level, format=fmt, datefmt="%Y-%m-%d %H:%M:%S")
+
+
+# ── 날짜 유틸 ────────────────────────────────────────────────
+def generate_monthly_ranges(start: str, end: str) -> list[tuple[str, str]]:
+    """start~end 기간을 월별로 분할하여 (시작일, 종료일) 리스트를 반환한다.
+
+    예: ('2025-04-01', '2025-06-15')
+        → [('2025-04-01', '2025-04-30'), ('2025-05-01', '2025-05-31'), ('2025-06-01', '2025-06-15')]
+    """
+    s = pd.Timestamp(start)
+    e = pd.Timestamp(end)
+    ranges: list[tuple[str, str]] = []
+
+    current = s
+    while current <= e:
+        month_end = (current + pd.offsets.MonthEnd(0)).normalize()
+        period_end = min(month_end, e)
+        ranges.append((current.strftime("%Y-%m-%d"), period_end.strftime("%Y-%m-%d")))
+        current = period_end + pd.Timedelta(days=1)
+
+    return ranges
+
+
+# ── ADLS 클라이언트 팩토리 ────────────────────────────────────
+def _get_adls_client():
+    return get_vault_manager().get_storage_client()
+
+
+# ── 체크포인트 (월별 중간 저장) ───────────────────────────────
+def _checkpoint_blob(keyword: str, month_start: str) -> str:
+    safe_name = re.sub(r"[^\w가-힣]", "_", keyword)
+    month_tag = month_start[:7]  # YYYY-MM
+    return f"{_CHECKPOINT_PREFIX}/{safe_name}_{month_tag}.json"
+
+
+def save_checkpoint(records: list[dict], keyword: str, month_start: str) -> str:
+    blob_path = _checkpoint_blob(keyword, month_start)
+    try:
+        fs = _get_adls_client().get_file_system_client(_ADLS_CONTAINER)
+        fc = fs.get_file_client(blob_path)
+        data = json.dumps(records, ensure_ascii=False, indent=2).encode("utf-8")
+        fc.upload_data(data, overwrite=True, length=len(data))
+        logger.info("체크포인트 저장: %s (%d건)", blob_path, len(records))
+    except Exception as e:
+        logger.warning("체크포인트 ADLS 저장 실패 (스킵): %s", e)
+    return blob_path
+
+
+def load_checkpoint(keyword: str, month_start: str) -> list[dict] | None:
+    blob_path = _checkpoint_blob(keyword, month_start)
+    try:
+        fs = _get_adls_client().get_file_system_client(_ADLS_CONTAINER)
+        fc = fs.get_file_client(blob_path)
+        raw = fc.download_file().readall()
+        data = json.loads(raw.decode("utf-8"))
+        logger.info("체크포인트 로드: %s (%d건)", blob_path, len(data))
+        return data
+    except Exception:
+        return None
+
+
+# ── 최종 저장 (Parquet → ADLS) ───────────────────────────────
+def save_final(records: list[dict], keyword: str) -> str:
+    """Parquet으로 변환 후 ADLS에 업로드하고 ADLS 경로를 반환한다."""
+    safe_name = re.sub(r"[^\w가-힣]", "_", keyword)
+
+    df = pd.DataFrame(records)
+    if "newsId" in df.columns:
+        df = df.drop_duplicates(subset="newsId")
+
+    now = datetime.now()
+    blob_path = (
+        f"{_OUTPUT_PREFIX}/keyword={safe_name}"
+        f"/year={now.year}/month={now.month:02d}/articles.parquet"
+    )
+
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False, engine="pyarrow")
+    buf_bytes = buf.getvalue()
+
+    fs = _get_adls_client().get_file_system_client(_ADLS_CONTAINER)
+    fc = fs.get_file_client(blob_path)
+    fc.upload_data(buf_bytes, overwrite=True, length=len(buf_bytes))
+    logger.info("Parquet ADLS 저장: %s (%d건)", blob_path, len(df))
+    return blob_path
+
+
+# ── 진행률 ────────────────────────────────────────────────────
+def log_progress(keyword: str, month: str, page: int, total_pages: int, articles: int) -> None:
+    logger.info(
+        "[%s] %s — 페이지 %d/%d (누적 %d건)",
+        keyword,
+        month,
+        page,
+        total_pages,
+        articles,
+    )
+
+
+# ── 텍스트 정리 ──────────────────────────────────────────────
+def clean_text(text: str | None) -> str:
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def parse_date(date_str: str) -> str:
+    """다양한 날짜 형식을 YYYY-MM-DD로 정규화한다.
+
+    Google News의 상대 시간 표현(2 hours ago, 3 days ago 등)도 처리.
+    """
+    date_str = date_str.strip()
+
+    # 상대 시간 처리 (Google News: "2 hours ago", "3 days ago" 등)
+    relative = re.match(r"(\d+)\s+(minute|hour|day|week|month)s?\s+ago", date_str, re.IGNORECASE)
+    if relative:
+        num, unit = int(relative.group(1)), relative.group(2).lower()
+        delta_map = {"minute": 1, "hour": 60, "day": 1440, "week": 10080, "month": 43200}
+        from datetime import timedelta
+
+        dt = datetime.now() - timedelta(minutes=num * delta_map.get(unit, 1))
+        return dt.strftime("%Y-%m-%d")
+
+    for fmt in ("%Y/%m/%d", "%Y-%m-%d", "%Y.%m.%d", "%b %d, %Y", "%B %d, %Y"):
+        try:
+            return datetime.strptime(date_str, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return date_str


### PR DESCRIPTION
## 개요
Google News 크롤러를 재사용 가능한 컨테이너로 리팩토링하고 Azure Container Instance 배포를 위한 인프라를 구성합니다.

## 변경 내용

### 코드 리팩토링
- **config.py**: 하드코딩된 키워드·날짜를 환경변수로 교체 (KEYWORDS, DATE_START, DATE_END), HEADLESS=True
- **utils.py**: 로컬 파일시스템 저장 → ADLS Gen2로 전환
  - 체크포인트: \
aw/news/google/checkpoints/{keyword}_{YYYY-MM}.json\
  - 최종 출력: \
aw/news/google/keyword={kw}/year={Y}/month={M}/articles.parquet\
  - vault_manager.get_storage_client()\ 활용 (컨테이너 flat import 지원)
- **crawling_google_news.py**: \crawl_keyword(keyword, date_start, date_end)\ 시그니처 변경으로 재사용성 확보
- **main.py** (신규): 컨테이너 엔트리포인트

### Docker / ACI
- **apps/google-news-crawler/Dockerfile**: mcr.microsoft.com/playwright/python:v1.49.1-jammy 기반
- **apps/google-news-crawler/requirements.txt**: 의존성 명세
- **apps/google-news-crawler/.dockerignore**

### Azure 인프라
- ACR **sense3dtacr** (koreacentral, Standard) 생성
- 이미지 빌드·푸시 완료: \sense3dtacr.azurecr.io/google-news-crawler:latest\

## 사용 방법

# ACI one-shot 실행
az container create \\
  --resource-group 3dt-2nd-team1 \\
  --name sense-news-crawler \\
  --image sense3dtacr.azurecr.io/google-news-crawler:latest \\
  --assign-identity \\
  --environment-variables \\
    KEY_VAULT_URL=https://kv-3dt-team1.vault.azure.net/ \\
    KEYWORDS='SK Hynix,Samsung Electronics' \\
    DATE_START=2025-04-01 \\
  --restart-policy Never \\
  --location koreacentral
\\\

> ACI 생성 후 MI에 **Key Vault Secrets User** + **Storage Blob Data Contributor** 권한 부여 필요

## 관련 이슈
Closes #21