### PR TITLE
[Docs] 프로젝트 문서 현행화 (아키텍처·구현계획 동기화)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,39 +8,50 @@
 외부 데이터 소스
        │
        ▼
-Azure Data Factory (ADF)
- ├─ 원시 데이터 수집 → ADLS Gen2 (Raw Layer)
- └─ 파이프라인 JSON 코드 관리 → adf/ 폴더
+Azure Data Factory (ADF) ── 타이머 트리거 기반 오케스트레이션
+ ├─ ACI Activity        → Google News 크롤러 (Playwright one-shot)
+ ├─ Functions Activity  → 네이버 뉴스, 환율(FX) 수집
+ ├─ Custom Activity     → Yahoo Finance 매크로·퀀트, 관세청 수출통계
+ └─ 파이프라인 JSON, parquet     → adf/ 폴더
 
-ADLS Gen2 (Azure Data Lake Storage Gen2)
- ├─ raw/       원본 데이터 (ADF가 적재)
+       │  수집 결과
+       ▼
+ADLS Gen2 (Azure Data Lake Storage Gen2) — 3dtteam1adls
+ ├─ raw/       원본 데이터 (수집기가 적재)
  ├─ curated/   전처리 완료 데이터 (Databricks가 생성)
  └─ feature/   ML용 피처 데이터 (Databricks가 생성)
 
-Azure Databricks
- ├─ raw → curated : 데이터 클렌징·변환
- ├─ curated → feature : 피처 엔지니어링
+Azure Databricks (sense-adb)
+ ├─ raw → curated : 데이터 클렌징·변환 (시계열 보간, TF-IDF)
+ ├─ curated → feature : 피처 엔지니어링 (ABSA, 벡터 임베딩)
  └─ 공통 모듈 사용 : src/utils/vault_manager.py
 
 Azure ML Studio
- ├─ feature → 모델 학습 (CommandJob)
+ ├─ feature → 모델 학습 (CommandJob, XGBoost/LightGBM)
  ├─ MLflow 실험 트래킹 (Git commit hash 태깅)
- └─ 결과 저장 → Azure SQL Database
+ └─ 결과 저장 → PostgreSQL
 
 Azure Database for PostgreSQL
- └─ 최종 예측·분석 결과 서빙
+ ├─ 최종 예측·분석 결과 서빙
+ └─ pgvector 확장 → RAG 하이브리드 검색
+
+Power BI / Web App / AI Agent
+ └─ PostgreSQL ↔ 대시보드·리포트·RAG 서빙
 ```
 
 ## 서비스별 역할
 
 | 서비스 | 역할 | Git 경로 |
 |---|---|---|
-| Azure Data Factory | 데이터 수집·오케스트레이션 | `adf/` |
-| ADLS Gen2 | 데이터 레이크 (raw·curated·feature) | _데이터는 Git에 없음_ |
-| Databricks | 대용량 전처리·피처 엔지니어링 | `src/`, `notebooks/` |
+| Azure Data Factory | **파이프라인 오케스트레이션** (타이머 트리거, Activity 호출) | `adf/` |
+| Azure Container Registry (`sense3dtacr`) | 컨테이너 이미지 저장소 (ACR Build) | _인프라, Git 외부_ |
+| Azure Container Instances | One-shot 크롤링 실행 (Google News) | `src/ingestion/google_news_crawler/Dockerfile` |
+| Azure Functions | 이벤트/배치 수집 (네이버 뉴스, 환율 FX) | `src/ingestion/naver_collectors/`, `apps/fx-collector/` |
+| ADLS Gen2 (`3dtteam1adls`) | 데이터 레이크 (raw·curated·feature) | _데이터는 Git에 없음_ |
+| Databricks (`sense-adb`) | 대용량 전처리·피처 엔지니어링 | `src/`, `notebooks/` |
 | ML Studio | 모델 학습·실험 관리 | `src/models/` |
-| Azure Database for PostgreSQL | 결과 데이터 저장·서빙 (`sense_db`) | _인프라, Git 외부_ |
-| Azure Key Vault | 모든 자격 증명 중앙 관리 | `src/utils/vault_manager.py` |
+| Azure Database for PostgreSQL | 결과 데이터 저장·서빙 (`sense_db`, `pgvector`) | _인프라, Git 외부_ |
+| Azure Key Vault (`kv-3dt-team1`) | 모든 자격 증명 중앙 관리 | `src/utils/vault_manager.py` |
 
 ## 인증 구조
 
@@ -72,6 +83,8 @@ DefaultAzureCredential
 | Databricks | Spark conf OAuth (Service Principal) | psycopg / JDBC | vault_manager 또는 dbutils.secrets |
 | Data Factory | Linked Service (Managed Identity) | Linked Service (KV 비밀 참조) | UI에서 Key Vault 직접 연결 |
 | ML Studio | vault_manager + DataLakeServiceClient | vault_manager + psycopg/SQLAlchemy | DefaultAzureCredential (Managed Identity) |
+| ACI (Google News) | vault_manager + DataLakeServiceClient | — | System-Assigned MI → Key Vault Secrets User |
+| Azure Functions | vault_manager / Binding | — | Managed Identity → Key Vault Secrets User |
 
 ## 로컬 개발 환경 설정
 

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -209,29 +209,66 @@ gh project create --owner 3dt-project-team --title "3dt-2nd-project 칸반"
   - `AllowAzureServices` 방화벽 규칙 ✅
 - [x] Databricks SP ADLS 권한 — `sense-databricks-sp` → Storage Blob Data Contributor ✅
 - [x] fx-collector (Azure Functions) Managed Identity → Key Vault Secrets User ✅
+- [x] Azure Databricks workspace 생성 — `sense-adb` (koreacentral, Standard SKU) ✅
+- [x] Azure Container Registry 생성 — `sense3dtacr` (koreacentral, Standard, admin 활성화) ✅
+- [x] Google News 크롤러 ACI 컨테이너 이미지 빌드 & 푸시 — `sense3dtacr.azurecr.io/google-news-crawler:latest` ✅
 - [ ] ADF Managed Identity → Key Vault Secrets User (ADF 생성 후, issue #11)
 - [ ] ML Studio Managed Identity → Key Vault Secrets User (ML Studio 생성 후, issue #11)
 
-### M2: 데이터 수집 (ADF)
-- [ ] Linked Service 연결 구성 (ADLS, PostgreSQL, Key Vault)
-- [ ] 원본 데이터 수집 파이프라인 구현 → `adf/` 폴더에 JSON 저장
-- [ ] 트리거 설정 (스케줄 또는 이벤트 기반)
+### M2: 데이터 수집
+
+> ADF = 오케스트레이션 레이어 (타이머 트리거). 수집 실행은 ACI / Azure Functions / Python 스크립트.
+
+#### ✅ 완료
+- [x] Google News 크롤러 (ACI) — RSS + Playwright 2단계 크롤링, ADLS `raw/news/google/` 적재
+- [x] 네이버 뉴스 크롤러 (Azure Functions) — 검색 API + Playwright 본문 크롤링
+- [x] Yahoo Finance 매크로·주가 수집 스크립트 — `src/ingestion/yahoo_finance_crawler.py`
+- [x] 환율(FX) 수집 (Azure Functions) — `apps/fx-collector/`, 한국수출입은행 API
+- [x] 관세청 수출입 통계 수집 — `src/utils/kr_public_data_customs.py`, HS Code 8542 기반
+
+#### ❌ 미완료
+- [ ] ADF Linked Service 연결 구성 (ADLS, PostgreSQL, Key Vault)
+- [ ] ADF 수집 파이프라인 — ACI Activity (Google News), Functions Activity (Naver/FX), Custom Activity (Yahoo/관세청)
+- [ ] ADF 타이머 트리거 설정 (일 1회 또는 장 마감 후)
+- [ ] 수집 파이프라인 JSON 저장 → `adf/` 폴더
 
 ### M3: 전처리 (Databricks)
 - [ ] 클러스터 Init Script 등록 (`notebooks/init_script_install_uv.sh`)
 - [ ] vault_manager 연동 및 ADLS Spark conf 설정
+- [ ] 시계열 결측치 Forward Fill 보간 (국가별 휴장일 통일)
+- [ ] Spark TF-IDF 기반 동적 키워드 모멘텀
+- [ ] Azure OpenAI 연동 (뉴스 요약, ABSA 감성 분석)
+- [ ] Summary-based Indexing 벡터 임베딩
 - [ ] 데이터 클렌징·변환 → `curated/` 저장
 - [ ] 피처 엔지니어링 → `feature/` 저장
 
 ### M4: 모델링 (ML Studio)
 - [ ] 컴퓨팅 클러스터 구성
 - [ ] Feature 데이터 Datastore 등록
+- [ ] XGBoost/LightGBM 하방 리스크 예측 모델 학습
 - [ ] 학습 잡 제출 (`src/models/aml_train_example.py` 참고)
 - [ ] MLflow 실험 트래킹 + Git commit hash 태깅
 
 ### M5: 서빙
 - [ ] 예측 결과 Azure Database for PostgreSQL 적재
+- [ ] PostgreSQL `pgvector` 확장 + 하이브리드 검색 구현
+- [ ] Power BI 시각화 대시보드 (XAI 피처 중요도 포함)
+- [ ] Web App + AI Agent RAG 서빙
 - [ ] 최종 파이프라인 End-to-End 검증
+
+---
+
+## 일정 (9 영업일 — 4/3 ~ 4/15)
+
+| Day | 날짜 | 마일스톤 | 상태 |
+|-----|------|---------|------|
+| 1–2 | 4/3–4/4 | M0 GitHub 세팅 + M1 인프라 프로비저닝 | ✅ 완료 |
+| 3–4 | 4/7–4/8 | M1 추가 인프라 (ACR, Databricks) + M2 수집기 구현 | ✅ 완료 |
+| 5 | 4/9 | M2 ADF 오케스트레이션 파이프라인 구성 | 🔜 |
+| 6 | 4/10 | M3 Databricks 전처리 (Bronze → Silver → Gold) | 🔜 |
+| 7 | 4/11 | M3 LLM 연동 + 피처 엔지니어링 | 🔜 |
+| 8 | 4/14 | M4 ML 학습 + M5 PostgreSQL 적재 | 🔜 |
+| 9 | 4/15 | M5 서빙 (Power BI + Web App + AI Agent) | 🔜 |
 
 ## 관련 문서
 - 아키텍처 개요: [architecture.md](architecture.md)


### PR DESCRIPTION
## Summary
<!-- 한 줄: 무엇을 왜 변경했는지 -->
- 프로젝트 제안서(ref/)와 공식 문서(docs/)가 실제 구현 상태와 괴리되어 있어 전면 동기화했습니다.

## Changes
### docs/architecture.md
- 데이터 흐름 다이어그램: ADF 오케스트레이션 → ACI/Functions/Custom Activity → ADLS 구조 반영
- 서비스 테이블: ACR (sense3dtacr), ACI, Azure Functions 추가 (6 → 9 서비스)
- 연동 방식 테이블: ACI, Azure Functions 행 추가

### docs/implementation_plan.md
- **M1 인프라**: ACR, Databricks workspace, ACI 이미지 빌드 완료 항목 추가
- **M2 데이터 수집**: 수집기별 완료/미완료 분리 (Google News ACI ✅, Naver Functions ✅, Yahoo Finance ✅, FX Functions ✅, 관세청 ✅)
- **M3~M5**: 세부 태스크 확장 (전처리, 모델링, 서빙 상세 항목)
- **일정표 추가**: 9 영업일 (4/3~4/15) Day 별 마일스톤 매핑

## Test
<!-- 실행한 테스트/확인 방법 (없으면 N/A) -->
- N/A

## Related
Closes #30