### PR TITLE
feat: add Naver news crawler ACI deployment code

### DIFF
--- a/docs/cicd/aci_naver_news_crawler.md
+++ b/docs/cicd/aci_naver_news_crawler.md
@@ -1,0 +1,295 @@
+# Naver News Crawler — ACI 배포 가이드
+
+> **대상**: `3dtteam1adls`의 `raw/news/naver/` 경로에 네이버 뉴스 JSON을 수집·저장하는  
+> One-shot Azure Container Instance 크롤러
+
+---
+
+## 1. 사전 준비
+
+### 1-1. 필수 도구
+
+```bash
+# 설치 확인
+az --version        # Azure CLI 2.60+
+docker --version    # Docker Desktop (로컬 빌드 시에만 필요)
+```
+
+> **Azure CLI 미설치 시** → [설치 가이드](https://learn.microsoft.com/cli/azure/install-azure-cli)
+
+### 1-2. Azure 로그인
+
+```bash
+az login
+az account set --subscription 27db5ec6-d206-4028-b5e1-6004dca5eeef
+```
+
+### 1-3. 리소스 정보 확인
+
+| 항목 | 값 |
+|------|-----|
+| 리소스 그룹 | `3dt-2nd-team1` |
+| ACR | `sense3dtacr` (koreacentral) |
+| Key Vault | `kv-3dt-team1` |
+| ADLS 계정 | `3dtteam1adls` |
+| ADLS 컨테이너 | `raw` |
+
+---
+
+## 2. 이미지 빌드 & ACR 푸시
+
+> **리포지토리 루트**에서 실행합니다.  
+> ACR 빌드는 Docker Desktop 없이도 가능합니다 (클라우드 빌드).
+
+```bash
+az acr build \
+  --registry sense3dtacr \
+  --image naver-news-crawler:latest \
+  --file src/ingestion/naver_collectors/Dockerfile \
+  .
+```
+
+### 이미지 확인
+
+```bash
+az acr repository show-tags \
+  --name sense3dtacr \
+  --repository naver-news-crawler \
+  --output table
+```
+
+---
+
+## 3. ACR Admin 자격증명 확인
+
+ACI는 ACR에 접근하기 위해 admin 계정이 필요합니다.
+
+```bash
+az acr credential show --name sense3dtacr --query "{username:username, password:passwords[0].value}" -o json
+```
+
+출력 예시:
+```json
+{
+  "username": "sense3dtacr",
+  "password": "xxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+`username`과 `password`를 메모해 두세요.
+
+---
+
+## 4. ACI 생성 및 실행
+
+### 4-1. 기본 실행 (삼성전자 + SK하이닉스)
+
+```bash
+az container create \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --image sense3dtacr.azurecr.io/naver-news-crawler:latest \
+  --registry-login-server sense3dtacr.azurecr.io \
+  --registry-username <acr-admin-user> \
+  --registry-password <acr-admin-password> \
+  --assign-identity \
+  --environment-variables \
+    KEY_VAULT_URL=https://kv-3dt-team1.vault.azure.net/ \
+    KEYWORDS="삼성전자,SK하이닉스" \
+    DATE_START=2025-04-01 \
+    ADLS_ACCOUNT=3dtteam1adls \
+    ADLS_CONTAINER=raw \
+  --restart-policy Never \
+  --os-type Linux \
+  --cpu 2 \
+  --memory 4 \
+  --location koreacentral
+```
+
+### 4-2. 날짜 범위 지정
+
+```bash
+az container create \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --image sense3dtacr.azurecr.io/naver-news-crawler:latest \
+  --registry-login-server sense3dtacr.azurecr.io \
+  --registry-username <acr-admin-user> \
+  --registry-password <acr-admin-password> \
+  --assign-identity \
+  --environment-variables \
+    KEY_VAULT_URL=https://kv-3dt-team1.vault.azure.net/ \
+    KEYWORDS="삼성전자,SK하이닉스" \
+    DATE_START=2025-01-01 \
+    DATE_END=2025-12-31 \
+    ADLS_ACCOUNT=3dtteam1adls \
+    ADLS_CONTAINER=raw \
+  --restart-policy Never \
+  --os-type Linux \
+  --cpu 2 \
+  --memory 4 \
+  --location koreacentral
+```
+
+### 환경변수 설명
+
+| 변수 | 필수 | 기본값 | 설명 |
+|------|------|--------|------|
+| `KEY_VAULT_URL` | ✅ | — | `https://kv-3dt-team1.vault.azure.net/` |
+| `KEYWORDS` | ❌ | `삼성전자,SK하이닉스` | 콤마로 구분된 네이버 검색 키워드 |
+| `DATE_START` | ❌ | `2025-04-01` | 수집 시작일 `YYYY-MM-DD` |
+| `DATE_END` | ❌ | 실행 당일 | 수집 종료일 `YYYY-MM-DD` |
+| `ADLS_ACCOUNT` | ❌ | `3dtteam1adls` | ADLS Gen2 계정명 |
+| `ADLS_CONTAINER` | ❌ | `raw` | ADLS 컨테이너명 |
+
+### 키워드 → 디렉토리명 매핑
+
+ADLS 저장 경로에는 한글 대신 영어 디렉토리명이 사용됩니다.  
+매핑은 `naver_news_crawler.py`의 `KEYWORD_EN_MAP`에서 관리합니다.
+
+| KEYWORDS 값 | ADLS 디렉토리명 |
+|-------------|----------------|
+| `삼성전자` | `samsung` |
+| `SK하이닉스` | `skhynix` |
+
+**새 키워드 추가 방법**: `naver_news_crawler.py`의 `KEYWORD_EN_MAP`에 추가 후 이미지 재빌드
+
+```python
+KEYWORD_EN_MAP = {
+    "삼성전자": "samsung",
+    "SK하이닉스": "skhynix",
+    "현대차": "hyundai",   # 추가 예시
+}
+```
+
+---
+
+## 5. ACI Managed Identity에 권한 부여
+
+> ACI 생성 후 한 번만 수행하면 됩니다.
+
+### 5-1. ACI의 Principal ID 확인
+
+```bash
+az container show \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --query "identity.principalId" -o tsv
+```
+
+`<PRINCIPAL_ID>`로 메모합니다.
+
+### 5-2. Key Vault — Secrets User 권한 부여
+
+```bash
+az role assignment create \
+  --assignee <PRINCIPAL_ID> \
+  --role "Key Vault Secrets User" \
+  --scope $(az keyvault show --name kv-3dt-team1 --query id -o tsv)
+```
+
+### 5-3. ADLS — Storage Blob Data Contributor 권한 부여
+
+```bash
+az role assignment create \
+  --assignee <PRINCIPAL_ID> \
+  --role "Storage Blob Data Contributor" \
+  --scope $(az storage account show --name 3dtteam1adls --resource-group 3dt-2nd-team1 --query id -o tsv)
+```
+
+> 권한 전파에 최대 2~3분이 소요될 수 있습니다.
+
+---
+
+## 6. 실행 상태 확인 및 로그
+
+### 상태 확인
+
+```bash
+az container show \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --query "{status:instanceView.state, exitCode:instanceView.currentState.exitCode}" \
+  -o table
+```
+
+| `status` | 의미 |
+|----------|------|
+| `Running` | 크롤링 중 |
+| `Succeeded` | 정상 완료 |
+| `Failed` | 오류 발생 → 로그 확인 |
+
+### 실시간 로그
+
+```bash
+az container logs \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --follow
+```
+
+---
+
+## 7. 결과 데이터 확인
+
+크롤링 완료 후 ADLS에 다음 경로로 JSON 파일이 저장됩니다.
+
+```
+raw/news/naver/source={keyword}/month={YYYY-MM}/news_{keyword}_{YYYYMM}.json
+```
+
+예시 (삼성전자, 2025년 4월):
+```
+raw/news/naver/source=samsung/month=2025-04/news_samsung_202504.json
+raw/news/naver/source=skhynix/month=2025-04/news_skhynix_202504.json
+```
+
+---
+
+## 8. 재실행
+
+기존 ACI 컨테이너는 `--restart-policy Never`이므로 재실행하려면 삭제 후 재생성합니다.
+
+```bash
+# 기존 컨테이너 삭제
+az container delete \
+  --resource-group 3dt-2nd-team1 \
+  --name naver-news-crawler \
+  --yes
+
+# 재생성 (4-1 또는 4-2 명령 반복)
+az container create ...
+```
+
+> ⚡ **체크포인트 덕분에** 동일 키워드·날짜 조합은 ADLS에 이미 수집된 데이터를 건너뜁니다.
+
+---
+
+## 9. 코드 수정 후 재배포
+
+```bash
+# 1. 이미지 재빌드
+az acr build \
+  --registry sense3dtacr \
+  --image naver-news-crawler:latest \
+  --file src/ingestion/naver_collectors/Dockerfile \
+  .
+
+# 2. 기존 ACI 삭제
+az container delete --resource-group 3dt-2nd-team1 --name naver-news-crawler --yes
+
+# 3. ACI 재생성 (4-1 명령 참고)
+az container create ...
+```
+
+---
+
+## 10. 관련 파일
+
+```
+src/ingestion/naver_collectors/naver_crawler
+├── Dockerfile          # 컨테이너 이미지 정의
+├── requirements.txt    # Python 의존성
+├── .dockerignore
+└── naver_news_crawler.py             # 크롤링 + ADLS 저장 로직
+```

--- a/src/ingestion/naver_collectors/naver_crawler/.dockerignore
+++ b/src/ingestion/naver_collectors/naver_crawler/.dockerignore
@@ -1,0 +1,9 @@
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/.env
+**/.env.*
+**/data/
+**/output/
+**/bronze/
+**/.git

--- a/src/ingestion/naver_collectors/naver_crawler/Dockerfile
+++ b/src/ingestion/naver_collectors/naver_crawler/Dockerfile
@@ -1,0 +1,42 @@
+# Naver News Crawler — Azure Container Instance 배포용
+#
+# 빌드 (리포지토리 루트에서 실행):
+#   az acr build --registry sense3dtacr \
+#     --image naver-news-crawler:latest \
+#     --file src/ingestion/naver_collectors/Dockerfile .
+#
+# ACI one-shot 실행 예시:
+#   az container create \
+#     --resource-group 3dt-2nd-team1 \
+#     --name naver-news-crawler \
+#     --image sense3dtacr.azurecr.io/naver-news-crawler:latest \
+#     --registry-login-server sense3dtacr.azurecr.io \
+#     --registry-username <acr-admin-user> \
+#     --registry-password <acr-admin-password> \
+#     --assign-identity \
+#     --environment-variables \
+#         KEY_VAULT_URL=https://kv-3dt-team1.vault.azure.net/ \
+#         KEYWORDS="삼성전자,SK하이닉스" \
+#         DATE_START=2025-04-01 \
+#     --restart-policy Never \
+#     --location koreacentral
+#
+# 필수 환경변수:
+#   KEY_VAULT_URL  : https://<vault-name>.vault.azure.net/
+#   KEYWORDS       : 콤마 구분 키워드 (기본: "삼성전자,SK하이닉스")
+#   DATE_START     : YYYY-MM-DD (기본: 2025-04-01)
+#   DATE_END       : YYYY-MM-DD (기본: 오늘)
+#   ADLS_ACCOUNT   : ADLS 계정명 (기본: 3dtteam1adls)
+#   ADLS_CONTAINER : ADLS 컨테이너명 (기본: raw)
+
+FROM mcr.microsoft.com/playwright/python:v1.49.1-jammy
+
+WORKDIR /app
+
+COPY src/ingestion/naver_collectors/naver_crawler/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+RUN playwright install chromium
+
+COPY src/ingestion/naver_collectors/naver_crawler/ /app/
+
+CMD ["python", "naver_news_crawler.py"]

--- a/src/ingestion/naver_collectors/naver_crawler/naver_news_crawler.py
+++ b/src/ingestion/naver_collectors/naver_crawler/naver_news_crawler.py
@@ -1,0 +1,421 @@
+import asyncio
+import hashlib
+import json
+import os
+import re
+import warnings
+from datetime import date, datetime
+from itertools import groupby
+
+import aiohttp
+import pandas as pd
+
+# Azure
+from azure.identity import DefaultAzureCredential
+from azure.storage.filedatalake import DataLakeServiceClient
+from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
+from playwright_stealth import stealth_async
+
+# ──────────────────────────────────────────────
+# 환경변수
+# ──────────────────────────────────────────────
+KEY_VAULT_URL = os.environ.get("KEY_VAULT_URL", "https://kv-3dt-team1.vault.azure.net/")
+KEYWORDS_ENV = os.environ.get("KEYWORDS", "삼성전자,SK하이닉스")
+DATE_START = os.environ.get("DATE_START", "2025-04-01")
+DATE_END = os.environ.get("DATE_END", date.today().isoformat())
+ADLS_ACCOUNT = os.environ.get("ADLS_ACCOUNT", "3dtteam1adls")
+ADLS_CONTAINER = os.environ.get("ADLS_CONTAINER", "raw")
+
+KEYWORDS = [k.strip() for k in KEYWORDS_ENV.split(",")]
+
+# 한글 키워드 → 영어 디렉토리명 매핑
+KEYWORD_EN_MAP = {
+    "삼성전자": "samsung",
+    "SK하이닉스": "skhynix",
+}
+
+
+def to_en(keyword):
+    """한글 키워드를 영어 디렉토리명으로 변환 (매핑 없으면 그대로 소문자)"""
+    return KEYWORD_EN_MAP.get(keyword, keyword.lower().replace(" ", "_"))
+
+
+# ──────────────────────────────────────────────
+# ADLS 클라이언트 (Managed Identity)
+# ──────────────────────────────────────────────
+def get_adls_client():
+    credential = DefaultAzureCredential()
+    return DataLakeServiceClient(
+        account_url=f"https://{ADLS_ACCOUNT}.dfs.core.windows.net", credential=credential
+    )
+
+
+def upload_to_adls(adls_client, records, keyword, month_str):
+    """JSON 레코드를 ADLS raw/news/naver/source={keyword_en}/month={month_str}/ 에 업로드"""
+    keyword_en = to_en(keyword)
+    file_path = (
+        f"news/naver/source={keyword_en}/month={month_str}/"
+        f"news_{keyword_en}_{month_str.replace('-', '')}.json"
+    )
+
+    fs_client = adls_client.get_file_system_client(ADLS_CONTAINER)
+    file_client = fs_client.get_file_client(file_path)
+
+    # 기존 파일 있으면 merge
+    existing = []
+    try:
+        download = file_client.download_file()
+        existing = json.loads(download.readall().decode("utf-8"))
+    except Exception:
+        pass
+
+    existing.extend(records)
+    data = json.dumps(existing, ensure_ascii=False, indent=2).encode("utf-8")
+    file_client.upload_data(data, overwrite=True)
+    print(f"      ☁️  ADLS 업로드: {file_path} ({len(existing)}건 누적)")
+
+
+# ──────────────────────────────────────────────
+# 크롤러 로직 (test.py 그대로)
+# ──────────────────────────────────────────────
+GARBAGE_KEYWORDS = ["로그인", "회원가입", "기사제보", "지면보기", "구독하기", "전체기사"]
+MAX_CONCURRENT = 5
+
+
+def is_garbage(text):
+    if not text:
+        return True
+    return sum(1 for kw in GARBAGE_KEYWORDS if kw in text) >= 2
+
+
+def extract_news_id(url):
+    try:
+        if "n.news.naver.com" in url:
+            match = re.search(r"/article/(\d+)/(\d+)", url)
+            if match:
+                return f"naver_{match.group(1)}_{match.group(2)}"
+        if "yna.co.kr" in url:
+            match = re.search(r"/view/(AKR\w+)", url)
+            if match:
+                return f"yna_{match.group(1)}"
+        if "hankyung.com" in url:
+            match = re.search(r"/article/(\w+)", url)
+            if match:
+                return f"hankyung_{match.group(1)}"
+        if "mk.co.kr" in url:
+            match = re.search(r"/article/(\d+)", url)
+            if match:
+                return f"mk_{match.group(1)}"
+        if "edaily.co.kr" in url:
+            match = re.search(r"/view/(\w+)", url)
+            if match:
+                return f"edaily_{match.group(1)}"
+        if "chosun.com" in url:
+            match = re.search(r"/([A-Z0-9]{20,})", url)
+            if match:
+                return f"chosun_{match.group(1)}"
+        if "newsis.com" in url:
+            match = re.search(r"/(NISX\w+)", url)
+            if match:
+                return f"newsis_{match.group(1)}"
+        return "hash_" + hashlib.md5(url.encode()).hexdigest()[:12]
+    except Exception:
+        return "hash_" + hashlib.md5(url.encode()).hexdigest()[:12]
+
+
+def find_best_selector(soup):
+    candidates = []
+    for tag in soup.find_all(["div", "article", "section"]):
+        text = tag.get_text(strip=True)
+        if len(text) < 200:
+            continue
+        tag_id = tag.get("id", "")
+        tag_cls = " ".join(tag.get("class", []))
+        identifier = (tag_id + tag_cls).lower()
+        if any(
+            kw in identifier
+            for kw in [
+                "article",
+                "body",
+                "content",
+                "news",
+                "text",
+                "view",
+                "story",
+            ]
+        ):
+            if not is_garbage(text):
+                candidates.append((len(text), text))
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def parse_body(html):
+    soup = BeautifulSoup(html, "html.parser")
+    meta = soup.find("meta", {"property": "og:article:published_time"})
+    pub_date = meta["content"] if meta else None
+
+    selectors = [
+        "#newsct_article",
+        "#articleBodyContents",
+        "#article-view-content-div",
+        ".article_txt",
+        ".art_body",
+        ".news_body",
+        ".article-body__content",
+        ".article_body",
+        "#content-body",
+        ".article-body",
+        ".article-body-content",
+        ".view-article",
+        "#articleView",
+        ".story-news-article",
+        "#articlebody",
+        ".art_txt",
+        "#newsEndContents",
+        "#content",
+        ".news-article-content",
+        ".view_text",
+        "#textBody",
+        "#articleText",
+        ".article_view",
+        ".text_area",
+        "#newsContent",
+        "#fusion-app",
+        ".article_txt_area",
+        ".article-content",
+        "#article-body",
+        "#articleBody",
+        "div[class*='articleBody']",
+        "div[class*='article_body']",
+        "div[class*='article-body']",
+        "div[id*='article']",
+        "article",
+    ]
+    body_text = None
+    for sel in selectors:
+        tag = soup.select_one(sel)
+        if not tag:
+            continue
+        text = tag.get_text(separator="\n", strip=True)
+        if len(text) > 100 and not is_garbage(text):
+            body_text = text
+            break
+    if not body_text:
+        body_text = find_best_selector(soup)
+
+    return pub_date, body_text
+
+
+async def fetch_with_aiohttp(session, url):
+    try:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/146.0.0.0 Safari/537.36"
+            ),
+            "Accept-Language": "ko-KR,ko;q=0.9",
+            "Referer": "https://search.naver.com/",
+        }
+        async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=5)) as res:
+            html = await res.text()
+            return html
+    except Exception:
+        return None
+
+
+async def get_article_detail_async(url, semaphore, context, session):
+    async with semaphore:
+        html = await fetch_with_aiohttp(session, url)
+        if html:
+            pub_date, body_text = parse_body(html)
+            if body_text:
+                return pub_date, body_text
+        try:
+            page = await context.new_page()
+            await stealth_async(page)
+            await page.goto(url, timeout=10000, wait_until="domcontentloaded")
+            await page.wait_for_timeout(800)
+            html = await page.content()
+            await page.close()
+            pub_date, body_text = parse_body(html)
+            return pub_date, body_text
+        except Exception:
+            return None, None
+
+
+async def fetch_hits(page, keyword, ds, ymd):
+    url = (
+        f"https://search.naver.com/search.naver?where=news&query={keyword}"
+        f"&sort=1&pd=3&ds={ds}&de={ds}"
+        f"&nso=so:dd,p:from{ymd}to{ymd},a:all"
+    )
+    await page.goto(url, wait_until="domcontentloaded")
+    await page.wait_for_timeout(2000)
+
+    prev_height = 0
+    while True:
+        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        await page.wait_for_timeout(100)
+        new_height = await page.evaluate("document.body.scrollHeight")
+        if new_height == prev_height:
+            break
+        prev_height = new_height
+
+    html = await page.content()
+    soup = BeautifulSoup(html, "html.parser")
+
+    hits = []
+    for span in soup.select("span[class*='headline']"):
+        title = span.get_text(strip=True)
+        a_tag = span.find_parent("a", href=True)
+        if not title or not a_tag:
+            continue
+        link = a_tag["href"]
+        press = ""
+        body_span = span.find_next("span", class_=lambda v: v and "body2" in v)
+        if body_span:
+            press = body_span.get_text(strip=True)
+        hits.append((title, link, press))
+
+    return hits
+
+
+def already_collected_adls(adls_client, keyword, date_str):
+    """ADLS에서 해당 날짜 데이터가 이미 수집됐는지 확인"""
+    month_str = date_str[:7]
+    keyword_en = to_en(keyword)
+    file_path = (
+        f"news/naver/source={keyword_en}/month={month_str}/"
+        f"news_{keyword_en}_{month_str.replace('-', '')}.json"
+    )
+    try:
+        fs_client = adls_client.get_file_system_client(ADLS_CONTAINER)
+        file_client = fs_client.get_file_client(file_path)
+        download = file_client.download_file()
+        existing = json.loads(download.readall().decode("utf-8"))
+        return any(r["adjustedDate"] == date_str for r in existing)
+    except Exception:
+        return False
+
+
+async def crawl_all(start, end):
+    adls_client = get_adls_client()
+    dates = list(pd.date_range(start, end))
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/146.0.0.0 Safari/537.36"
+            ),
+            locale="ko-KR",
+        )
+        search_page = await context.new_page()
+        await stealth_async(search_page)
+
+        async with aiohttp.ClientSession() as session:
+            all_records = []
+
+            for keyword in KEYWORDS:
+                print(f"\n{'=' * 50}")
+                print(f"🔍 키워드: {keyword}")
+                print(f"{'=' * 50}")
+
+                month_grouped = groupby(dates, key=lambda d: d.strftime("%Y-%m"))
+
+                for month_str, month_dates in month_grouped:
+                    print(f"\n  📅 [{keyword}] {month_str} 수집 시작")
+                    month_records = []
+
+                    for date_val in month_dates:
+                        ds = date_val.strftime("%Y.%m.%d")
+                        ymd = date_val.strftime("%Y%m%d")
+                        date_str = date_val.strftime("%Y-%m-%d")
+
+                        if already_collected_adls(adls_client, keyword, date_str):
+                            print(f"    ⏭️  {ds} 이미 수집됨 — 건너뜀")
+                            continue
+
+                        print(f"\n    [{keyword}] {ds} 수집 중…")
+                        hits = await fetch_hits(search_page, keyword, ds, ymd)
+                        print(f"      → {len(hits)}건 수집")
+
+                        tasks = [
+                            get_article_detail_async(link, semaphore, context, session)
+                            for _, link, _ in hits
+                        ]
+                        results = await asyncio.gather(*tasks)
+
+                        daily_records = []
+                        for (title, link, press), (pub, body_text) in zip(hits, results):
+                            news_id = extract_news_id(link)
+                            has_body = "✅" if body_text else "❌"
+                            print(f"      • {has_body} {press or '언론사없음'} | {title[:45]}...")
+                            daily_records.append(
+                                {
+                                    "source": keyword,
+                                    "newsId": news_id,
+                                    "url": link,
+                                    "pubDate": pub,
+                                    "adjustedDate": date_str,
+                                    "headline": title,
+                                    "press": press,
+                                    "body": body_text if body_text else "",
+                                    "fetchedAt": datetime.utcnow().isoformat() + "+00:00",
+                                }
+                            )
+
+                        if daily_records:
+                            day_body = sum(1 for r in daily_records if r["body"])
+                            message = (
+                                f"      💾 {date_str}: {len(daily_records)}건 (본문 {day_body}건)"
+                            )
+                            print(message)
+                            month_records.extend(daily_records)
+
+                        all_records.extend(daily_records)
+                        await asyncio.sleep(0.5)
+
+                    # 월 단위로 ADLS 업로드
+                    if month_records:
+                        upload_to_adls(adls_client, month_records, keyword, month_str)
+
+        await browser.close()
+
+    df = pd.DataFrame(all_records)
+    if df.empty:
+        print("\n✅ 수집 완료 — 새로운 데이터 없음")
+        return df
+
+    total = len(df)
+    has_body = df["body"].apply(lambda x: bool(x)).sum()
+
+    print(f"\n{'=' * 50}")
+    print(f"✅ 수집 완료 — 총 {total}건")
+    print(f"   본문 성공: {has_body}건 ({has_body / total * 100:.1f}%)")
+    print(f"   본문 실패: {total - has_body}건 ({(total - has_body) / total * 100:.1f}%)")
+
+    for kw in KEYWORDS:
+        kw_df = df[df["source"] == kw]
+        kw_body = kw_df["body"].apply(lambda x: bool(x)).sum()
+        print(f"      {kw}: {len(kw_df)}건 (본문 {kw_body}건)")
+
+    dedup_count = len(df.drop_duplicates("newsId"))
+    print(f"\n   ℹ️  newsId 중복 제거 시: {total} → {dedup_count}건")
+    return df
+
+
+if __name__ == "__main__":
+    warnings.filterwarnings("ignore")
+    print("🚀 네이버 뉴스 크롤러 시작")
+    print(f"   키워드: {KEYWORDS}")
+    print(f"   기간: {DATE_START} ~ {DATE_END}")
+    asyncio.run(crawl_all(DATE_START, DATE_END))

--- a/src/ingestion/naver_collectors/naver_crawler/requirements.txt
+++ b/src/ingestion/naver_collectors/naver_crawler/requirements.txt
@@ -1,0 +1,8 @@
+aiohttp>=3.9.0
+playwright>=1.49.0
+tf-playwright-stealth>=1.0.6
+beautifulsoup4>=4.12.0
+pandas>=2.2.0
+azure-identity>=1.19.0
+azure-keyvault-secrets>=4.9.0
+azure-storage-file-datalake>=12.19.0


### PR DESCRIPTION
## Summary
<!-- 한 줄: 무엇을 왜 변경했는지 -->
- 네이버 뉴스 크롤러를 Azure Functions 대신 ACI(Azure Container Instance)로 배포
- 장시간 크롤링 특성상 Functions 10분 제한을 초과하여 ACI 방식으로 변경

## Changes
<!-- 핵심 변경 2~5개 -->
- src/ingestion/naver_collectors/naver_crawler/naver_news_crawler.py: 네이버 뉴스 크롤링 + ADLS 저장 로직 구현
- src/ingestion/naver_collectors/naver_crawler/Dockerfile: ACI 배포용 컨테이너 이미지 정의
- src/ingestion/naver_collectors/naver_crawler/requirements.txt: Python 의존성 정의
- docs/cicd/aci_naver_news_crawler.md: ACI 배포 가이드 문서 추가

## Test
<!-- 실행한 테스트/확인 방법 (없으면 N/A) -->
- ACI 생성 및 Managed Identity ADLS 권한 부여 완료
- 
## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #33 
