### PR TITLE
[Feat] Naver News Preprocessing - HTML 정리 및 description 요약 배…

### DIFF
--- a/notebooks/init_script_install_uv.sh
+++ b/notebooks/init_script_install_uv.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
-# Databricks 클러스터 Init Script — uv 설치 및 공통 라이브러리 세팅
-#
-# 등록 방법:
-#   1. 이 파일을 DBFS에 업로드:
-#      databricks fs cp notebooks/init_script_install_uv.sh dbfs:/FileStore/scripts/install_uv.sh
-#   2. 클러스터 > Edit > Advanced Options > Init Scripts
-#      > dbfs:/FileStore/scripts/install_uv.sh 등록
-
 set -e
 
 echo "[Init] uv 설치 시작..."
+# curl -LsSf https://astral.sh/uv/install.sh | sh
+# source "$HOME/.cargo/env"
+
 curl -LsSf https://astral.sh/uv/install.sh | sh
-source "$HOME/.cargo/env"
+export PATH="$HOME/.local/bin:$PATH"
+# source "$HOME/.cargo/env"
+# uv pip install --system azure-identity azure-keyvault-secrets azure-storage-file-datalake
+
+pip install --upgrade pip -q
+pip install uv -q
+
 echo "[Init] uv 설치 완료: $(uv --version)"
 
+
 echo "[Init] 공통 라이브러리 설치 중..."
-uv pip install --system \
-  azure-identity \
-  azure-keyvault-secrets \
-  azure-storage-file-datalake \
-  python-dotenv \
-  sqlalchemy
+uv pip install --system --break-system-packages azure-identity azure-keyvault-secrets azure-storage-file-datalake python-dotenv sqlalchemy
+# uv pip install --system \
+#   azure-identity \
+#   azure-keyvault-secrets \
+#   azure-storage-file-datalake \
+#   python-dotenv \
+#   sqlalchemy
 
 echo "[Init] 설치 완료"

--- a/notebooks/naver_news_preprocessing.ipynb
+++ b/notebooks/naver_news_preprocessing.ipynb
@@ -1,0 +1,934 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "2a0a576d-daee-4d99-b8f5-837e06e112ee",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 환경설정"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "dc6bce43-7fa1-47b5-a6d6-4658f0520ea6",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sh\n",
+    "# 필수 Azure SDK 패키지 설치\n",
+    "uv pip install azure-identity azure-keyvault-secrets azure-storage-file-datalake"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "aaef9c59-7e2b-42fd-8ca3-8c7e8c0b1ea9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"KEY_VAULT_URL\"] = \"https://kv-3dt-team1.vault.azure.net/\"\n",
+    "\n",
+    "sys.path.insert(0, \"/Workspace/Repos/3dt030@msacademy.msai.kr/3dt-2nd-project/src\")\n",
+    "\n",
+    "# ✅ import 전에 싱글톤 초기화\n",
+    "import utils.vault_manager\n",
+    "utils.vault_manager._instance = None\n",
+    "\n",
+    "# ✅ 그 다음 vault 새로 가져오기\n",
+    "from utils.vault_manager import get_vault_manager\n",
+    "vault = get_vault_manager()\n",
+    "\n",
+    "print(\"client_id:\", vault.get_secret(\"adls-client-id\"))\n",
+    "print(\"client_secret:\", vault.get_secret(\"adls-client-secret\"))\n",
+    "print(\"tenant_id:\", vault.get_secret(\"adls-tenant-id\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "e1a5a3ca-c67f-4554-82a2-e2e372ef2258",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 데이터 로드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "72505566-53a4-459c-937a-1781344ac6c8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "vault.get_storage_client(\"3dtteam1adls\")\n",
+    "\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import StringType\n",
+    "\n",
+    "BRONZE_BASE = \"abfss://raw@3dtteam1adls.dfs.core.windows.net/news/naver/\"\n",
+    "\n",
+    "# 와일드카드로 JSON 파일 직접 읽기\n",
+    "df_raw = (spark.read\n",
+    "    .option(\"mergeSchema\", \"true\")\n",
+    "    .option(\"multiLine\", \"true\")   # ← 이거 추가!\n",
+    "    .json(f\"{BRONZE_BASE}source=*/month=*/*.json\")\n",
+    ")\n",
+    "\n",
+    "print(f\"총 로드: {df_raw.count():,}건\")\n",
+    "print(f\"컬럼: {df_raw.columns}\")\n",
+    "df_raw.printSchema()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "55a74a71-ea8f-4f5c-ac60-76ee1052413d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 경로 자동 생성 (파일명 신경 안 써도 됨)\n",
+    "sources = [\"samsung\", \"skhynix\"]\n",
+    "months = (\n",
+    "    [f\"2025-{m:02d}\" for m in range(4, 13)] +  # 2025-04 ~ 2025-12\n",
+    "    [f\"2026-{m:02d}\" for m in range(1, 5)]      # 2026-01 ~ 2026-04\n",
+    ")\n",
+    "\n",
+    "paths = [\n",
+    "    f\"{BRONZE_BASE}source={s}/month={m}/\"\n",
+    "    for s in sources\n",
+    "    for m in months\n",
+    "]\n",
+    "\n",
+    "print(f\"총 경로 수: {len(paths)}개\")\n",
+    "\n",
+    "df_raw = (spark.read\n",
+    "    .option(\"mergeSchema\", \"true\")\n",
+    "    .option(\"multiLine\", \"true\")\n",
+    "    .json(paths)\n",
+    ")\n",
+    "\n",
+    "print(f\"총 로드: {df_raw.count():,}건\")\n",
+    "print(f\"컬럼: {df_raw.columns}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "2daec49c-2b23-463b-a37d-0117514128f3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### 컬럼 표준화 + pubDate 처리"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "2364a0bd-c77f-4350-abe2-4a723d04f31d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df = (df_raw\n",
+    "    .withColumnRenamed(\"newsId\",       \"news_id\")\n",
+    "    .withColumnRenamed(\"pubDate\",      \"pub_date_raw\")\n",
+    "    .withColumnRenamed(\"adjustedDate\", \"adjusted_date\")\n",
+    "    .withColumnRenamed(\"fetchedAt\",    \"fetched_at\")\n",
+    "    .withColumnRenamed(\"source\",       \"stock_keyword\")  # samsung/skhynix\n",
+    ")\n",
+    "\n",
+    "# pubDate 전체 null → adjustedDate 대체\n",
+    "df = df.withColumn(\n",
+    "    \"pub_date\",\n",
+    "    F.coalesce(\n",
+    "        F.to_date(\"pub_date_raw\",  \"yyyy-MM-dd\"),\n",
+    "        F.to_date(\"adjusted_date\", \"yyyy-MM-dd\")\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# news_source는 항상 naver\n",
+    "df = df.withColumn(\"news_source\", F.lit(\"naver\"))\n",
+    "\n",
+    "print(f\"컬럼: {df.columns}\")\n",
+    "display(df.limit(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "71789f3d-3b56-4bd9-b882-4b3d3be9a678",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df = df.drop(\"naverUrl\", \"pub_date_raw\", \"adjusted_date\")\n",
+    "\n",
+    "df = df.withColumnRenamed(\"fetched_at\", \"published_time\")\n",
+    "\n",
+    "print(f\"최종 컬럼: {df.columns}\")\n",
+    "display(df.limit(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e9c7d3f5-da0e-41ba-9515-8388edf1846a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 컬럼 순서 정리\n",
+    "df = df.select(\n",
+    "    \"news_id\",           # PK\n",
+    "    \"stock_keyword\",     # samsung/skhynix\n",
+    "    \"news_source\",       # naver\n",
+    "    \"pub_date\",          # 발행 날짜\n",
+    "    \"published_time\",    # 발행 시각\n",
+    "    \"press\",             # 언론사\n",
+    "    \"headline\",          # 기사 제목\n",
+    "    \"body\",              # 원문 본문\n",
+    "    \"description\",       # 3줄 요약 (LLM 예정)\n",
+    "    \"url\",               # 원문 URL\n",
+    ")\n",
+    "\n",
+    "print(f\"컬럼 순서: {df.columns}\")\n",
+    "display(df.limit(10))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "cb3ea38a-0956-4948-9ee3-f8a833cd44ea",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### samsung, skhynix 중복 기사 전처리\n",
+    "- url 기준으로 중복 처리 \n",
+    "- 겹치는 기사를 stock_keyword->samsung,skhynix 설정 후 중복된 기사 제거"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "71092b19-afc9-4b9f-96fd-42cab9e2e66b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 1. 한글 → 영어 표준화\n",
+    "df = df.withColumn(\n",
+    "    \"stock_keyword\",\n",
+    "    F.when(F.col(\"stock_keyword\") == \"삼성전자\", \"samsung\")\n",
+    "     .when(F.col(\"stock_keyword\") == \"SK하이닉스\", \"skhynix\")\n",
+    "     .otherwise(F.col(\"stock_keyword\"))\n",
+    ")\n",
+    "\n",
+    "# 2. URL 기준으로 머지\n",
+    "# - news_id는 버리고 (samsung용/skhynix용 각각 다르게 생성됐으므로)\n",
+    "# - URL이 같으면 stock_keyword만 합치고 나머지는 첫 번째 값 사용\n",
+    "df_merged = df.groupBy(\"url\").agg(\n",
+    "    F.first(\"pub_date\").alias(\"pub_date\"),\n",
+    "    F.first(\"published_time\").alias(\"published_time\"),\n",
+    "    F.first(\"news_source\").alias(\"news_source\"),\n",
+    "    F.first(\"press\").alias(\"press\"),\n",
+    "    F.first(\"headline\").alias(\"headline\"),\n",
+    "    F.first(\"body\").alias(\"body\"),\n",
+    "    F.first(\"description\").alias(\"description\"),\n",
+    "    F.concat_ws(\",\", F.collect_set(\"stock_keyword\")).alias(\"stock_keyword\")\n",
+    ")\n",
+    "\n",
+    "# 3. 결과 확인\n",
+    "print(f\"머지 전: {df.count():,}건\")\n",
+    "print(f\"머지 후: {df_merged.count():,}건\")\n",
+    "print(f\"중복 제거: {df.count() - df_merged.count():,}건\")\n",
+    "\n",
+    "display(\n",
+    "    df_merged.groupBy(\"stock_keyword\")\n",
+    "             .count()\n",
+    "             .orderBy(\"count\", ascending=False)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f182e349-db55-40bd-9704-c449eb716941",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### 본문 html, 특수문자 등 정리"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "73c83de2-ce9b-408e-9882-06d4bfd3c7d3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "import re\n",
+    "\n",
+    "# 1. HTML 및 불필요한 텍스트 제거 UDF\n",
+    "def clean_text(text):\n",
+    "    if text is None:\n",
+    "        return None\n",
+    "    # HTML 태그 제거\n",
+    "    text = re.sub(r'<[^>]+>', '', text)\n",
+    "    # HTML 엔티티 제거 (&amp; &lt; 등)\n",
+    "    text = re.sub(r'&[a-zA-Z]+;', '', text)\n",
+    "    # 특수문자 정리 (문장부호 제외)\n",
+    "    text = re.sub(r'[\\r\\n\\t]+', ' ', text)\n",
+    "    # 연속 공백 정리\n",
+    "    text = re.sub(r' +', ' ', text)\n",
+    "    return text.strip()\n",
+    "\n",
+    "clean_udf = F.udf(clean_text)\n",
+    "\n",
+    "# 2. body, headline, description 컬럼 클렌징\n",
+    "df_cleaned = df_merged.withColumn(\"body\", clean_udf(F.col(\"body\"))) \\\n",
+    "                      .withColumn(\"headline\", clean_udf(F.col(\"headline\"))) \\\n",
+    "                      .withColumn(\"description\", clean_udf(F.col(\"description\")))\n",
+    "\n",
+    "# 3. 키워드별 10개씩 샘플 출력\n",
+    "keywords = [\"samsung\", \"skhynix\", \"skhynix,samsung\"]\n",
+    "\n",
+    "for kw in keywords:\n",
+    "    print(f\"\\n{'='*60}\")\n",
+    "    print(f\"📰 stock_keyword = '{kw}' 샘플 10건\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    df_cleaned.filter(F.col(\"stock_keyword\") == kw) \\\n",
+    "              .select(\"stock_keyword\", \"headline\", \"body\") \\\n",
+    "              .limit(10) \\\n",
+    "              .show(truncate=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "424fc38f-b4b9-43ff-96cf-240039c75f43",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### description 전처리\n",
+    "- **Azure OpenAI GPT-4o mini** 를 사용하여 본문(`body`)을 3줄 요약\n",
+    "- `description`이 없는 기사만 요약 처리 (있는 건 그대로 유지)\n",
+    "- **Batch API** 방식으로 제출 (최대 24시간 대기, 비용 50% 절감)\n",
+    "- 50,000건씩 분할하여 `.jsonl` 파일로 제출\n",
+    "- 1회차 전체 처리 후 이후 증분 데이터는 실시간 API로 처리"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "9cbeb9cc-423a-41bd-9a32-0c198483595c",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "#### 셀 1 - Batch 요청 파일 생성"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "79d37b96-2220-437b-b6a1-a3b74e70b114",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# description 없는 것만 추출\n",
+    "df_need_summary = df_cleaned.filter(\n",
+    "    F.col(\"description\").isNull() | (F.col(\"description\") == \"\")\n",
+    ").select(\"news_id\", \"body\").toPandas()\n",
+    "\n",
+    "print(f\"[INFO] 요약 필요 건수: {len(df_need_summary)}건\")\n",
+    "\n",
+    "# Batch API 요청 파일 생성 (50,000건씩 분할)\n",
+    "batch_size = 50000\n",
+    "chunks = [df_need_summary[i:i+batch_size] for i in range(0, len(df_need_summary), batch_size)]\n",
+    "\n",
+    "for idx, chunk in enumerate(chunks):\n",
+    "    output_file = f\"/tmp/batch_request_{idx+1}.jsonl\"\n",
+    "    with open(output_file, \"w\", encoding=\"utf-8\") as f:\n",
+    "        for _, row in chunk.iterrows():\n",
+    "            request = {\n",
+    "                \"custom_id\": str(row[\"news_id\"]),\n",
+    "                \"method\": \"POST\",\n",
+    "                \"url\": \"/chat/completions\",\n",
+    "                \"body\": {\n",
+    "                    \"model\": \"gpt-4o-mini\",\n",
+    "                    \"messages\": [\n",
+    "                        {\n",
+    "                            \"role\": \"system\",\n",
+    "                            \"content\": \"뉴스 기사를 3줄로 요약해주세요. 핵심 내용만 간결하게 작성하세요.\"\n",
+    "                        },\n",
+    "                        {\n",
+    "                            \"role\": \"user\",\n",
+    "                            \"content\": str(row[\"body\"])[:3000]  # 토큰 절약\n",
+    "                        }\n",
+    "                    ],\n",
+    "                    \"max_tokens\": 300\n",
+    "                }\n",
+    "            }\n",
+    "            f.write(json.dumps(request, ensure_ascii=False) + \"\\n\")\n",
+    "    print(f\"[OK] 파일 생성: {output_file} ({len(chunk)}건)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "0143dee5-d784-4702-8072-b4f60c95ed0c",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "#### 셀 2 - Batch 파일 업로드 및 작업 제출"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "92d1c6e2-049e-4fdc-890e-2b44a89f264b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from openai import AzureOpenAI\n",
+    "\n",
+    "# Azure OpenAI 클라이언트\n",
+    "client = AzureOpenAI(\n",
+    "    api_key=vault.get_secret(\"azure-openai-key\"),      # Key Vault에서 가져오기\n",
+    "    api_version=\"2024-07-01-preview\",\n",
+    "    azure_endpoint=vault.get_secret(\"azure-openai-endpoint\")\n",
+    ")\n",
+    "\n",
+    "batch_job_ids = []\n",
+    "\n",
+    "for idx in range(len(chunks)):\n",
+    "    file_path = f\"/tmp/batch_request_{idx+1}.jsonl\"\n",
+    "    \n",
+    "    # 파일 업로드\n",
+    "    with open(file_path, \"rb\") as f:\n",
+    "        uploaded_file = client.files.create(file=f, purpose=\"batch\")\n",
+    "    print(f\"[OK] 파일 업로드: {uploaded_file.id}\")\n",
+    "    \n",
+    "    # Batch 작업 제출\n",
+    "    batch_job = client.batches.create(\n",
+    "        input_file_id=uploaded_file.id,\n",
+    "        endpoint=\"/chat/completions\",\n",
+    "        completion_window=\"24h\"\n",
+    "    )\n",
+    "    batch_job_ids.append(batch_job.id)\n",
+    "    print(f\"[OK] Batch 제출: {batch_job.id}\")\n",
+    "\n",
+    "print(f\"\\n[INFO] 전체 Batch Job IDs: {batch_job_ids}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "723215f0-328e-461e-b363-bf707385b9f4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "#### 셀 3 - 상태 확인 (나중에 실행)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "c3ebdc82-cdfc-4628-b001-d3e91a5d2411",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 제출 후 나중에 상태 확인\n",
+    "for job_id in batch_job_ids:\n",
+    "    job = client.batches.retrieve(job_id)\n",
+    "    print(f\"Job {job_id}: {job.status} | 완료: {job.request_counts.completed} / 전체: {job.request_counts.total}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "865af77f-71f6-480d-a1f8-6804da18f3a6",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "#### 셀 4 - 결과 수집 및 df_final 생성"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f91397fe-47e6-4070-a82e-c53552b831d0",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "all_summaries = {}\n",
+    "\n",
+    "for job_id in batch_job_ids:\n",
+    "    job = client.batches.retrieve(job_id)\n",
+    "    \n",
+    "    if job.status != \"completed\":\n",
+    "        print(f\"[WARN] {job_id} 아직 미완료: {job.status}\")\n",
+    "        continue\n",
+    "    \n",
+    "    # 결과 다운로드\n",
+    "    result_content = client.files.content(job.output_file_id).text\n",
+    "    \n",
+    "    for line in result_content.strip().split(\"\\n\"):\n",
+    "        result = json.loads(line)\n",
+    "        news_id = result[\"custom_id\"]\n",
+    "        summary = result[\"response\"][\"body\"][\"choices\"][0][\"message\"][\"content\"]\n",
+    "        all_summaries[news_id] = summary\n",
+    "\n",
+    "print(f\"[OK] 요약 수집 완료: {len(all_summaries)}건\")\n",
+    "\n",
+    "# Spark DataFrame으로 변환\n",
+    "summary_df = spark.createDataFrame(\n",
+    "    pd.DataFrame(list(all_summaries.items()), columns=[\"news_id\", \"description_new\"])\n",
+    ")\n",
+    "\n",
+    "# 기존 df_cleaned와 합치기\n",
+    "df_has_summary = df_cleaned.filter(\n",
+    "    F.col(\"description\").isNotNull() & (F.col(\"description\") != \"\")\n",
+    ")\n",
+    "df_need_summary_spark = df_cleaned.filter(\n",
+    "    F.col(\"description\").isNull() | (F.col(\"description\") == \"\")\n",
+    ").drop(\"description\").join(summary_df, on=\"news_id\", how=\"left\") \\\n",
+    " .withColumnRenamed(\"description_new\", \"description\")\n",
+    "\n",
+    "df_final = df_has_summary.union(df_need_summary_spark)\n",
+    "print(f\"[OK] 최종 데이터: {df_final.count()}건\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "5b68ae9f-4258-4b1b-9909-a0ed8bf49f79",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## ------------------------------------------------------------------------------\n",
+    "#### 하루치 테스트 코드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "992b6d10-d44e-4038-b77f-58cbf99fba64",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "test_date = \"2025-04-01\"\n",
+    "\n",
+    "df_test = df_cleaned.filter(F.col(\"pub_date\") == test_date)\n",
+    "df_test_need = df_test.filter(\n",
+    "    F.col(\"description\").isNull() | (F.col(\"description\") == \"\")\n",
+    ")\n",
+    "\n",
+    "print(f\"[INFO] 테스트 데이터: {df_test.count()}건 ({test_date})\")\n",
+    "print(f\"[INFO] 요약 필요: {df_test_need.count()}건\")\n",
+    "\n",
+    "# 컬럼 확인\n",
+    "print(f\"[INFO] 컬럼 목록: {df_test_need.columns}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d0ad9911-a73b-4ffd-9805-272fde7fabfe",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 셀 2 - Batch 요청 파일 생성\n",
+    "import json\n",
+    "\n",
+    "df_test_pd = df_test_need.select(\"url\", \"body\").toPandas()\n",
+    "\n",
+    "output_file = \"/tmp/batch_test.jsonl\"\n",
+    "with open(output_file, \"w\", encoding=\"utf-8\") as f:\n",
+    "    for _, row in df_test_pd.iterrows():\n",
+    "        request = {\n",
+    "            \"custom_id\": str(row[\"url\"]),\n",
+    "            \"method\": \"POST\",\n",
+    "            \"url\": \"/chat/completions\",\n",
+    "            \"body\": {\n",
+    "                \"model\": \"gpt-4o-mini\",\n",
+    "                \"messages\": [\n",
+    "                    {\n",
+    "                        \"role\": \"system\",\n",
+    "                        \"content\": \"당신은 뉴스 요약 전문가입니다. 주어진 뉴스 기사를 핵심 내용 위주로 3줄로 요약해주세요.\"\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"role\": \"user\",\n",
+    "                        \"content\": str(row[\"body\"])[:3000]\n",
+    "                    }\n",
+    "                ],\n",
+    "                \"max_tokens\": 300\n",
+    "            }\n",
+    "        }\n",
+    "        f.write(json.dumps(request, ensure_ascii=False) + \"\\n\")\n",
+    "\n",
+    "print(f\"[OK] 파일 생성 완료: {df_test_pd.shape[0]}건\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "100c1da3-468d-4d14-8472-8cc56283b340",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 셀 3 - Batch 제출\n",
+    "\n",
+    "from openai import AzureOpenAI\n",
+    "\n",
+    "client = AzureOpenAI(\n",
+    "    api_key=vault.get_secret(\"azure-openai-key\"),\n",
+    "    api_version=\"2024-07-01-preview\",\n",
+    "    azure_endpoint=vault.get_secret(\"azure-openai-endpoint\")\n",
+    ")\n",
+    "\n",
+    "with open(\"/tmp/batch_test.jsonl\", \"rb\") as f:\n",
+    "    uploaded_file = client.files.create(file=f, purpose=\"batch\")\n",
+    "print(f\"[OK] 파일 업로드: {uploaded_file.id}\")\n",
+    "\n",
+    "batch_job = client.batches.create(\n",
+    "    input_file_id=uploaded_file.id,\n",
+    "    endpoint=\"/chat/completions\",\n",
+    "    completion_window=\"24h\"\n",
+    ")\n",
+    "batch_job_id = batch_job.id\n",
+    "print(f\"[OK] Batch 제출: {batch_job_id}\")\n",
+    "print(f\"[INFO] 상태: {batch_job.status}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "1956f7cc-4e80-441e-87b7-07404c03b503",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 셀 4 - 상태 확인 (나중에 실행)\n",
+    "job = client.batches.retrieve(batch_job_id)\n",
+    "print(f\"상태: {job.status}\")\n",
+    "print(f\"완료: {job.request_counts.completed} / 전체: {job.request_counts.total}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "9970ed13-4727-4304-a488-e223a8e285b4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 셀 5 - 결과 수집 및 확인\n",
+    "import pandas as pd\n",
+    "\n",
+    "# 완료 확인\n",
+    "job = client.batches.retrieve(batch_job_id)\n",
+    "if job.status != \"completed\":\n",
+    "    print(f\"[WARN] 아직 미완료: {job.status}\")\n",
+    "else:\n",
+    "    result_content = client.files.content(job.output_file_id).text\n",
+    "    summaries = {}\n",
+    "    \n",
+    "    for line in result_content.strip().split(\"\\n\"):\n",
+    "        result = json.loads(line)\n",
+    "        news_id = result[\"custom_id\"]\n",
+    "        summary = result[\"response\"][\"body\"][\"choices\"][0][\"message\"][\"content\"]\n",
+    "        summaries[news_id] = summary\n",
+    "    \n",
+    "    print(f\"[OK] 요약 수집: {len(summaries)}건\")\n",
+    "    \n",
+    "    # 샘플 출력\n",
+    "    for news_id, summary in list(summaries.items())[:3]:\n",
+    "        print(f\"\\n{'='*60}\")\n",
+    "        print(f\"news_id: {news_id}\")\n",
+    "        print(f\"요약:\\n{summary}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "5"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 8718118804139215,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "naver_news_preprocessing",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
…치 처리

## Summary
- Databricks 환경에서 네이버 뉴스 데이터 전처리 파이프라인 구현
- HTML 정리 및 Azure OpenAI Batch API 기반 description 자동 요약 처리 준비

## Changes
#### init_script_install_uv.sh
- uv 설치 경로 수정 (`$HOME/.cargo/env` → `$HOME/.local/bin`)
- pip으로 uv 설치 방식으로 변경 (`pip install uv -q`)
- 라이브러리 설치 방식 변경 (`--break-system-packages` 옵션 추가)

#### naver_news_preprocessing.ipynb
- HTML 태그 및 엔티티 제거 UDF 추가 (`clean_text`)
- body, headline, description 컬럼 클렌징 처리
- 키워드별(samsung / skhynix / skhynix,samsung) 샘플 10건 출력
- Azure OpenAI Batch API를 활용한 description 요약 처리 준비

#### 진행 상태
- [x] HTML 정리
- [x] 중복 제거
- [ ] Azure OpenAI Batch 요약 처리 (Key Vault 시크릿 등록 후 진행 예정)


## Test
<!-- 실행한 테스트/확인 방법 (없으면 N/A) -->
- N/A

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes 
