### PR TITLE
[Fix] vault.get_pg_connection() 연결 문자열 형식 자동 감지 처리

### DIFF
--- a/src/utils/vault_manager.py
+++ b/src/utils/vault_manager.py
@@ -179,11 +179,9 @@ class KeyVaultManager:
               - "sqlalchemy" → sqlalchemy.Engine. pd.read_sql / Session과 함께 사용하세요.
 
         Key Vault 시크릿:
-          pg-connection-string : PostgreSQL 연결 문자열 (libpq 형식)
-
-        연결 문자열 예시:
-          "host={server}.postgres.database.azure.com dbname={db}
-           user={user} password={pass} sslmode=require"
+          pg-connection-string : PostgreSQL 연결 문자열. 아래 두 형식 모두 지원합니다.
+            - SQLAlchemy URL 형식  : "postgresql+psycopg://user:pass@host/db?sslmode=require"
+            - libpq key=value 형식 : "host=... dbname=... user=... password=... sslmode=require"
         """
         connection_string = self.get_secret("pg-connection-string")
         if not connection_string:
@@ -192,17 +190,32 @@ class KeyVaultManager:
                 "KV 시크릿 'pg-connection-string' 또는 환경 변수 PG_CONNECTION_STRING을 설정하세요."
             )
 
+        # KV에 저장된 형식 자동 감지
+        # "postgresql://" 이나 "postgresql+<driver>://" 로 시작하면 URL 형식
+        _is_url = connection_string.startswith(("postgresql://", "postgresql+"))
+
         if engine == "sqlalchemy":
             from sqlalchemy import create_engine
 
-            return create_engine(
-                f"postgresql+psycopg:///?{connection_string}",
-                pool_pre_ping=True,
-            )
+            if _is_url:
+                # 이미 SQLAlchemy URL 형식 → 그대로 전달 (이중 인코딩 방지)
+                return create_engine(connection_string, pool_pre_ping=True)
+            else:
+                # libpq key=value 형식 → psycopg 쿼리 파라미터 방식으로 변환
+                return create_engine(
+                    f"postgresql+psycopg:///?{connection_string}",
+                    pool_pre_ping=True,
+                )
 
         import psycopg
 
-        return psycopg.connect(connection_string)
+        if _is_url:
+            # psycopg는 URI에서 "+psycopg" 드라이버 접미사를 인식하지 못함
+            # "postgresql+psycopg://" → "postgresql://" 로 변환
+            psycopg_uri = connection_string.replace("postgresql+psycopg://", "postgresql://", 1)
+            return psycopg.connect(psycopg_uri)
+        else:
+            return psycopg.connect(connection_string)
 
 
 # 모듈 레벨 싱글톤 — 다른 모듈에서 바로 import해서 사용


### PR DESCRIPTION
## Summary
`vault.get_pg_connection()` 메서드가 Key Vault 시크릿 형식(SQLAlchemy URL vs libpq)을 자동 감지하도록 수정합니다.

## Changes
- **형식 감지 추가**: \`connection_string.startswith((postgresql://, postgresql+))\` 로 URL 형식 여부 판단
- **SQLAlchemy 엔진**:  
- URL 형식 → \`create_engine(connection_string)\` 직접 전달 (이중 인코딩 제거)  
- libpq 형식 → \`create_engine(fpostgresql+psycopg:///?{connection_string})\` 기존 방식 유지
- **psycopg 드라이버**:  - URL 형식 → \`+psycopg\` 접미사 제거 후 \`psycopg.connect()\`  
- libpq 형식 → \`psycopg.connect(connection_string)\` 기존 방식 유지
- **docstring 업데이트**: libpq와 SQLAlchemy URL 양쪽 형식 지원 명시

## Test
- \`uv run ruff check src/utils/vault_manager.py --fix\` → All checks passed
- pre-commit (ruff + ruff-format + detect-secrets) 통과

## Related
issueCloses #56 